### PR TITLE
Issue 263: remove maintainers from dist csv

### DIFF
--- a/src/events/crawler/lib/stringify.js
+++ b/src/events/crawler/lib/stringify.js
@@ -29,8 +29,9 @@ export const csvForDay = function(data) {
     }
   }
 
-  // Drop coordinates
-  columns = columns.filter(column => column !== 'coordinates');
+  // Drop unwanted columns.
+  const unwanted = ['coordinates', 'maintainers'];
+  columns = columns.filter(column => !unwanted.includes(column));
 
   // Turn data into arrays
   const csvData = [columns];


### PR DESCRIPTION
Fix for https://github.com/lazd/coronadatascraper/issues/263.

Verified manually locally with `yarn start --location "Ventura County, CA, USA"`, and the rest of the columns were unchanged:

Old headings: `city,county,state,country,cases,deaths,recovered,tested,active,population,lat,long,url,maintainers,rating,tz,featureId`

New headings: `city,county,state,country,cases,deaths,recovered,tested,active,population,lat,long,url,rating,tz,featureId`

I don't see a way to add a regression test for this, but if there is, let me know and I'll update the PR.  Cheers!