### PR TITLE
viz tweak: transparent outlines on choropleth

### DIFF
--- a/site/lib/color.js
+++ b/site/lib/color.js
@@ -9,7 +9,7 @@ export const noCasesColor = '#ffffff';
 export const noPopulationDataColor = 'rgba(0,0,0,0)';
 
 export const outlineColorHighlight = 'rgb(0,0,0)';
-export const outlineColor = 'rgba(0, 0, 0, 0.3)';
+export const outlineColor = 'rgba(0, 0, 0, 0)';
 
 const choroplethColors = {
   stoplight: ['#eeffcd', '#b4ffa5', '#ffff00', '#ff7f00', '#ff0000'],


### PR DESCRIPTION
I find the gray borders on the choropleth to be really noisy. Especially when zoomed out, areas with a high density of admin boundaries (e.g. county borders in the eastern US) almost acquire an unintended additional map shade. 

Before: 

![image](https://user-images.githubusercontent.com/2136620/77743367-40fbef00-7018-11ea-8eeb-e7e4fe9818ba.png)

After:

![77743353-3ccfd180-7018-11ea-805d-59a0cddf4275](https://user-images.githubusercontent.com/2136620/77743954-28d89f80-7019-11ea-8af3-bbd013ca9b32.png)

