### PR TITLE
getArcGISCSVURL without the server name

### DIFF
--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -225,3 +225,66 @@ export const getArcGISCSVURL = async function(serverNumber, dashboardId, layerNa
   const { orgId } = dashboardManifest;
   return getArcGISCSVURLFromOrgId(serverNumber, orgId, layerName);
 };
+
+/**
+ * Find data source id for a widget from the manifest
+ *
+ * @param {*} dashboardId the ID of the dashboard
+ * @param {*} widgetName the name of the widget in the manifest
+ *
+ *
+ */
+const findArcGISFeatureDataSourceIDByName = function(manifest, widgetName) {
+  for (const w of manifest.widgets) {
+    if (w.name === widgetName) {
+      if (w.datasets.length !== 1) throw new Error('Expect only one dataset');
+      return w.datasets[0].dataSource.itemId;
+    }
+  }
+  throw new Error('Cannot find widget');
+};
+
+/**
+ * Get the URL for the CSV data from an ArcGIS dashboard
+ * @param {*} dashboardId the ID of the dashboard
+ * @param {*} widgetName the name of the widget in the manifest
+ *
+ * The dashboardId is passed to the iframe that renders URL.  For example,
+ *   If you have https://maps.arcgis.com/apps/opsdashboard/index.html#/ec4bffd48f7e495182226eee7962b422 is
+ *   dashboardId = ec4bffd48f7e495182226eee7962b422
+ *
+ * To get the widgetName, load the manifest, reformat it, and search for a widget that has a caption
+ * that matches the title of table shown in the UI.  The caption is HTML but some places put images
+ * instead of text so we should the name when scraping.  For example,
+ *    https://maps.arcgis.com/sharing/rest/content/items/ec4bffd48f7e495182226eee7962b422/data?f=json
+ * has a widget named 'COVID-19 Cases by County' which has a datasourceId = 24f4fcf164ad4b4280f08c8939dd5dc7
+ *
+ *
+ */
+export const getArcGISCSVURLByWidgetName = async function(dashboardId, widgetName) {
+  // 1. get the full manifest
+  const manifestUrl = `https://maps.arcgis.com/sharing/rest/content/items/${dashboardId}/data?f=json`;
+  const dashboardManifestFull = await json(manifestUrl);
+
+  // 2. find the datasourceID for the target
+  const datasourceId = findArcGISFeatureDataSourceIDByName(dashboardManifestFull, widgetName);
+  if (!datasourceId) throw new Error('Missing datasourceId');
+
+  // 3. get the orgID, layerName, and url from the data source
+  const sourceInfo = await json(`https://maps.arcgis.com/sharing/rest/content/items/${datasourceId}?f=json`);
+  const xorgId = sourceInfo.orgId;
+  const layerName = sourceInfo.name;
+  const serverName = sourceInfo.url.substr(0, 28);
+
+  // error checks...
+  if (!xorgId) throw new Error('Missing orgID');
+  if (!layerName) throw new Error('Missing layerName');
+  if (!serverName.endsWith('.com')) throw new Error('Could not parse server name');
+
+  // 4. get the serviceItemId for the layer.
+  const layerMetadata = await json(`${serverName}/${xorgId}/arcgis/rest/services/${layerName}/FeatureServer/0?f=json`);
+  const { serviceItemId } = layerMetadata;
+
+  // 5. build the URL for the content
+  return `https://opendata.arcgis.com/datasets/${serviceItemId}_0.csv`;
+};

--- a/src/shared/scrapers/USA/NJ/index.js
+++ b/src/shared/scrapers/USA/NJ/index.js
@@ -54,6 +54,22 @@ const scraper = {
       }
       counties.push(transform.sumData(counties));
       return counties;
+    },
+    '2020-3-26': async function() {
+      this.url = await fetch.getArcGISCSVURLByWidgetName(
+        'ec4bffd48f7e495182226eee7962b422',
+        'COVID-19 Cases by County'
+      );
+      const data = await fetch.csv(this.url);
+      const counties = [];
+      for (const county of data) {
+        counties.push({
+          county: parse.string(county.COUNTY_LAB),
+          cases: parse.number(county.TOTAL_CASES || 0)
+        });
+      }
+      counties.push(transform.sumData(counties));
+      return counties;
     }
   }
 };


### PR DESCRIPTION
Gets the full manifest and finds the data source based on
widget name.  From the data source, you can get the server.

** This code has not been run.  Please validate if you merge it **

Supersedes #382
