### PR TITLE
fix AUS ACT (deaths) and consolidate key lookup

### DIFF
--- a/src/shared/scrapers/AUS/NT/index.js
+++ b/src/shared/scrapers/AUS/NT/index.js
@@ -22,7 +22,6 @@ const scraper = {
     const $rowWithCases = $('.header-widget p:first-of-type');
     assert($rowWithCases.text().includes('confirmed cases'));
     const data = {
-      state: this.state,
       cases: parse.number($rowWithCases.text())
     };
     assert(data.cases > 0, 'Cases is not reasonable');

--- a/src/shared/scrapers/AUS/QLD/index.js
+++ b/src/shared/scrapers/AUS/QLD/index.js
@@ -30,7 +30,6 @@ const scraper = {
       const paragraph = $('#content h2:first-of-type + p').text();
       const { casesString } = paragraph.match(/state total to (?<casesString>\d+)./).groups;
       return {
-        state: this.state,
         cases: parse.number(casesString)
       };
     },
@@ -39,7 +38,6 @@ const scraper = {
       const $table = $('#content table');
       const $totalRow = $table.find('tbody > tr:last-child');
       const data = {
-        state: this.state,
         cases: parse.number($totalRow.find('td:last-child').text())
       };
       assert(data.cases > 0, 'Cases is not reasonable');

--- a/src/shared/scrapers/AUS/VIC/index.js
+++ b/src/shared/scrapers/AUS/VIC/index.js
@@ -5,8 +5,8 @@ import maintainers from '../../../lib/maintainers.js';
 
 // Changing free-text media release.
 // They have a PowerBI dashboard at https://app.powerbi.com/view?r=eyJrIjoiODBmMmE3NWQtZWNlNC00OWRkLTk1NjYtMjM2YTY1MjI2NzdjIiwidCI6ImMwZTA2MDFmLTBmYWMtNDQ5Yy05Yzg4LWExMDRjNGViOWYyOCJ9
-// No idea how to get the data out of that though.
-// We've emailed them on 2020-03-28 to try to get a usable format.
+// https://github.com/vungyn/vic-covid-19 has managed to scrape it.
+// We've emailed them on 2020-03-28 to try to get a more usable format.
 // For now lets fall back to the AUS index scraper when we can't scrape successfully.
 
 const scraper = {
@@ -32,7 +32,6 @@ const scraper = {
     const matches = paragraph.match(/cases in Victoria \w* (?<casesString>\d+)/) || {};
     const { casesString } = matches.groups || {};
     const data = {
-      state: this.state,
       cases: parse.number(casesString)
     };
 

--- a/src/shared/scrapers/AUS/_shared/get-data-with-tested-negative-applied.js
+++ b/src/shared/scrapers/AUS/_shared/get-data-with-tested-negative-applied.js
@@ -1,0 +1,13 @@
+/**
+ * @param {{ cases?: number; deaths?: number; recovered?: number; testedNegative?: number; tested?: number }} inputData
+ */
+const getTestedFromTestedNegative = inputData => {
+  const data = { ...inputData };
+  if (!data.tested && data.testedNegative > 0) {
+    data.tested = data.testedNegative + data.cases;
+    delete data.testedNegative;
+  }
+  return data;
+};
+
+export default getTestedFromTestedNegative;

--- a/src/shared/scrapers/AUS/_shared/get-key.js
+++ b/src/shared/scrapers/AUS/_shared/get-key.js
@@ -1,0 +1,12 @@
+const buildFragmentMatcher = lowerLabel => definition => lowerLabel.includes(Object.values(definition)[0]);
+
+const getKey = ({ label, labelFragmentsByKey }) => {
+  const lowerLabel = label.toLowerCase();
+  const definitionIndex = labelFragmentsByKey.findIndex(buildFragmentMatcher(lowerLabel));
+  if (definitionIndex === -1) {
+    throw new Error(`There is an unexpected label: ${lowerLabel}`);
+  }
+  return Object.keys(labelFragmentsByKey[definitionIndex])[0];
+};
+
+export default getKey;


### PR DESCRIPTION
Trying out some patterns for how best to lookup. Wondering if there can be a shared lookup across scrapers (like if the word deaths is included, then its very probable to be the deaths item).

AUS ACT has a death now, so they've added 'lives lost'.