### PR TITLE
Add scrapeDate to dist.json -- PR for discussion only

### DIFF
--- a/src/events/processor/write-data/index.js
+++ b/src/events/processor/write-data/index.js
@@ -2,6 +2,7 @@ import path from 'path';
 import * as fs from '../../../shared/lib/fs.js';
 import * as stringify from './stringify.js';
 import reporter from '../../../shared/lib/error-reporter.js';
+import * as datetime from '../../../shared/lib/datetime.js';
 
 const writeData = async ({ locations, featureCollection, report, options, sourceRatings }) => {
   let suffix = '';
@@ -11,7 +12,14 @@ const writeData = async ({ locations, featureCollection, report, options, source
     suffix = `-${process.env.SCRAPE_DATE}`;
   }
 
-  await fs.writeFile(path.join('dist', `data${suffix}.json`), JSON.stringify(locations, null, 2));
+  // Add scrape date.
+  const scrapeDate = process.env.SCRAPE_DATE || datetime.getYYYYMD();
+  const outlocs = locations.map(loc => {
+    loc.scrapeDate = scrapeDate;
+    return loc;
+  });
+
+  await fs.writeFile(path.join('dist', `data${suffix}.json`), JSON.stringify(outlocs, null, 2));
 
   await fs.writeCSV(path.join('dist', `data${suffix}.csv`), stringify.csvForDay(locations));
 


### PR DESCRIPTION
An attempt at #179.  I attempted to explain this in Slack, but it appears that my meaning was lost, so here are the comments again.  Hopefully this will clarify the argument, so someone can point out the mistakes in my thoughts.

---

All scrapers seem to be using the libraries in src/shared/lib/fetch/index.js (at least, I hope they are, haven’t triple-checked).  The exported methods are page,  json, csv, tsv, pdf, and headless (omitting the getArcGIS* methods, which don’t mention date).

They all have the same declarations: `const <methodname> = async (url, date, options)`, and for each date = “date the date associated with this resource, or false if a timeseries data”
Checking the calls, none of the scrapers ever pass the date, or if they do, it’s “false”. (I can show the grep search results for each if anyone needs it) 

All of these methods (except for headless) call `get.js`’s
`export const get = async (url, type, date = process.env.SCRAPE_DATE || datetime.getYYYYMD(), options = {})`
headless has `date = process.env.SCRAPE_DATE || datetime.getYYYYMD()` for its args.

In other words, date is always going to be `process.env.SCRAPE_DATE || datetime.getYYYYMD()`

Since every call uses the `process.env.SCRAPE_DATE || datetime.getYYYYMD()` for its cache lookup, it seems that we could just add that to as the `scrapeDate`