### PR TITLE
deprecate NH + fix errors in MN

### DIFF
--- a/src/shared/scrapers/USA/MN/index.js
+++ b/src/shared/scrapers/USA/MN/index.js
@@ -156,10 +156,6 @@ const scraper = {
         const cases = item.attributes.COVID19POS || 0;
         const county = geography.addCounty(item.attributes.CTY_NAME);
 
-        if (datetime.scrapeDateIsAfter(item.attributes.CV_Updated)) {
-          throw new Error(`Data only available until ${new Date(item.attributes.CV_Updated).toLocaleString()}`);
-        }
-
         counties.push({
           county,
           cases

--- a/src/shared/scrapers/USA/NH/index.js
+++ b/src/shared/scrapers/USA/NH/index.js
@@ -4,6 +4,7 @@ import * as transform from '../../../lib/transform.js';
 import * as geography from '../../../lib/geography/index.js';
 import * as pdfUtils from '../../../lib/pdf.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -35,7 +36,6 @@ const scraper = {
   scraper: {
     '0': async function() {
       const body = await fetch.pdf(this.url);
-
       const rows = pdfUtils.asWords(body, 0, 1000).map(row => row[0]);
 
       const counties = [];
@@ -74,6 +74,10 @@ const scraper = {
       counties.push(transform.sumData(counties));
 
       return counties;
+    },
+    '2020-3-31': async function() {
+      await fetch.pdf(this.url);
+      throw new DeprecatedError('New Hampshire stopped reporting county-level data as of 2020/3/31');
     }
   }
 };


### PR DESCRIPTION
New Hampshire's source stopped reporting county-level data and I'm unable to find any government source that's showing it.

MN was checking for a non-existent attribute `item.attributes.CV_Updated`, this check was removed.