### PR TITLE
update: NJ now reporting county deaths

### DIFF
--- a/src/shared/scrapers/USA/NJ/index.js
+++ b/src/shared/scrapers/USA/NJ/index.js
@@ -54,6 +54,20 @@ const scraper = {
       }
       counties.push(transform.sumData(counties));
       return counties;
+    },
+    '2020-3-31': async function() {
+      this.url = await fetch.getArcGISCSVURL(7, 'ec4bffd48f7e495182226eee7962b422', 'DailyCaseCounts');
+      const data = await fetch.csv(this.url);
+      const counties = [];
+      for (const county of data) {
+        counties.push({
+          county: parse.string(county.COUNTY_LAB),
+          cases: parse.number(county.TOTAL_CASE || 0),
+          deaths: parse.number(county.DEATHS || 0)
+        });
+      }
+      counties.push(transform.sumData(counties));
+      return counties;
     }
   }
 };


### PR DESCRIPTION
also fixed a column name change for total cases