### PR TITLE
Fix Issue 363: Changes to UT & MI, USA

### DIFF
--- a/src/shared/scrapers/USA/MI/index.js
+++ b/src/shared/scrapers/USA/MI/index.js
@@ -143,7 +143,7 @@ const scraper = {
         deaths += detroitDeaths;
       }
 
-      if (county === 'Out of State County' || county === 'Other County') {
+      if (county === 'Out of State County' || county === 'Other County' || county === 'Not Reported County') {
         unassignedObj.cases += cases;
         unassignedObj.deaths += deaths;
         return;

--- a/src/shared/scrapers/USA/UT/index.js
+++ b/src/shared/scrapers/USA/UT/index.js
@@ -53,7 +53,7 @@ const scraper = {
     }
     if (county === 'TriCounty') {
       counties.push({
-        county: 'TriCounty (Uintah, Duchesne, Daggett)',
+        county: 'Uintah, Duchesne, & Daggett Counties',
         cases,
         feature: geography.generateMultiCountyFeature(
           ['Uintah County, UT', 'Duchesne County, UT', 'Daggett County, UT'],
@@ -90,8 +90,12 @@ const scraper = {
     }
     if (county === 'Bear River') {
       counties.push({
-        city: geography.addCounty(county),
-        cases
+        county: 'Box Elder, Cache, & Rich Counties',
+        cases,
+        feature: geography.generateMultiCountyFeature(['Box Elder County, UT', 'Cache County, UT', 'Rich County, UT'], {
+          state: 'UT',
+          country: 'USA'
+        })
       });
       return;
     }


### PR DESCRIPTION
Fixes `Not Reported County` in Michigan as well as `Tri County Health District` and `Bear River Health District` in Utah.

Closes https://github.com/covidatlas/coronadatascraper/issues/363.