### PR TITLE
Add `timeseries` to ratings schema

### DIFF
--- a/src/shared/lib/schemas/ratings.json
+++ b/src/shared/lib/schemas/ratings.json
@@ -16,6 +16,10 @@
       "type": "boolean",
       "default": false
     },
+    "timeseries": {
+      "type": "boolean",
+      "default": false
+    },
     "certValidation": {
       "type": "boolean",
       "default": true


### PR DESCRIPTION
Just noticed that ESP was showing up as not a timeseries, then noticed that **all** sources where showing up as not a time series, whether they are or not. 

![image](https://user-images.githubusercontent.com/2136620/78150750-02ab6900-7438-11ea-8957-be215df1cdd5.png)

Tracked it down to the ratings schema, which was missing the `timeseries` property. 