### PR TITLE
Add --onlyUseCache CLI flag 

### DIFF
--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -31,6 +31,11 @@ const { argv } = yargs
     description: 'Suppress logs',
     type: 'boolean'
   })
+  .option('onlyUseCache', {
+    alias: 'c',
+    description: 'Only use cache (no http calls)',
+    type: 'boolean'
+  })
   .help()
   .alias('help', 'h');
 

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -18,15 +18,14 @@ import datetime from './lib/datetime/index.js';
 async function generate(date, options = {}) {
   options = { findFeatures: true, findPopulations: true, writeData: true, ...options };
 
-  if (date) {
-    process.env.SCRAPE_DATE = date;
-  } else {
-    delete process.env.SCRAPE_DATE;
-  }
+  if (date) process.env.SCRAPE_DATE = date;
+  else delete process.env.SCRAPE_DATE;
 
-  if (options.quiet) {
-    process.env.LOG_LEVEL = 'off';
-  }
+  const { onlyUseCache } = options;
+  if (onlyUseCache) process.env.ONLY_USE_CACHE = true;
+  else delete process.env.ONLY_USE_CACHE;
+
+  if (options.quiet) process.env.LOG_LEVEL = 'off';
 
   // JSON used for reporting
   const report = {

--- a/src/shared/lib/fetch/get.js
+++ b/src/shared/lib/fetch/get.js
@@ -43,8 +43,11 @@ export const get = async (url, type, date = datetime.scrapeDate() || datetime.ge
   };
 
   const cachedBody = await caching.getCachedFile(url, type, date, encoding);
+  const cacheMiss = cachedBody === caching.CACHE_MISS;
 
-  if (cachedBody === caching.CACHE_MISS || alwaysRun) {
+  const onlyUseCache = process.env.ONLY_USE_CACHE;
+
+  if (!onlyUseCache && (cacheMiss || alwaysRun)) {
     log('  🚦  Loading data for %s from server', url);
 
     if (disableSSL) {

--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -193,8 +193,10 @@ export const headless = async (url, date = datetime.scrapeDate() || datetime.get
   const { alwaysRun } = { alwaysRun: false, disableSSL: false, ...options };
 
   const cachedBody = await caching.getCachedFile(url, 'html', date);
+  const cacheMiss = cachedBody === caching.CACHE_MISS;
+  const onlyUseCache = process.env.ONLY_USE_CACHE;
 
-  if (cachedBody === caching.CACHE_MISS || alwaysRun) {
+  if (!onlyUseCache && (cacheMiss || alwaysRun)) {
     const fetchedBody = await fetchHeadless(url);
     await caching.saveFileToCache(url, 'html', date, fetchedBody);
 


### PR DESCRIPTION
Adds a CLI flag to prevent new http calls; only the existing cache files are used, to make it easier to make repeatable runs for testing purposes. 