### PR TITLE
feat: move running crawler for timeseries to its own process

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "tape tests/**/*-test.js | tap-spec",
     "test:watch": "tape-watch tests/**/*-test.js -p tap-spec",
     "test:tz": "tape scripts/testTimezones.js | tap-spec",
-    "timeseries": "node src/shared/timeseries.js",
+    "timeseries": "node src/shared/timeseries/index.js",
     "update": "npm run updateModules && rm -rf cache/* && npm run start",
     "updateModules": "git submodule update --remote",
     "pretty": "prettier --write '**/*.js'"

--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -31,6 +31,18 @@ const { argv } = yargs
     description: 'Suppress logs',
     type: 'boolean'
   })
+  .option('findFeatures', {
+    description: 'Include feature information in output data',
+    type: 'boolean'
+  })
+  .options('findPopulations', {
+    description: 'Include population information in output data',
+    type: 'boolean'
+  })
+  .options('writeData', {
+    description: 'Write to dist folder',
+    type: 'boolean'
+  })
   .help()
   .alias('help', 'h');
 

--- a/src/shared/timeseries/index.js
+++ b/src/shared/timeseries/index.js
@@ -2,14 +2,14 @@ const imports = require('esm')(module);
 
 const path = require('path');
 
-const generate = imports('./index.js').default;
-const argv = imports('./cli/cli-args.js').default;
-const fs = imports('./lib/fs.js');
-const transform = imports('./lib/transform.js');
-const geography = imports('./lib/geography/index.js');
-const datetime = imports('./lib/datetime/index.js').default;
+const argv = imports('../cli/cli-args.js').default;
+const fs = imports('../lib/fs.js');
+const transform = imports('../lib/transform.js');
+const geography = imports('../lib/geography/index.js');
+const datetime = imports('../lib/datetime/index.js').default;
+const runCrawler = imports('./runCrawler.js').default;
 
-const clearAllTimeouts = imports('./utils/timeouts.js').default;
+const clearAllTimeouts = imports('../utils/timeouts.js').default;
 
 // The props to keep on a date object
 const caseDataProps = ['cases', 'deaths', 'recovered', 'active', 'tested', 'growthFactor'];
@@ -190,7 +190,8 @@ async function generateTimeseries(options = {}) {
   const lastDate = dates[dates.length - 1];
   let featureCollection;
   for (const date of dates) {
-    const data = await generate(date === today ? undefined : date, {
+    const data = await runCrawler({
+      date: date === today ? undefined : date,
       findFeatures: date === lastDate,
       findPopulations: date === lastDate,
       writeData: false,

--- a/src/shared/timeseries/runCrawler.js
+++ b/src/shared/timeseries/runCrawler.js
@@ -1,0 +1,34 @@
+const path = require('path');
+const childProcess = require('child_process');
+
+/**
+ * Running crawler for each day in its own process.
+ *
+ * This will result in a slower execution time due to the child_process overheads,
+ * but it will ensure that timeseries never runs out of memory.
+ */
+export default options =>
+  new Promise((resolve, reject) => {
+    const child = childProcess.fork(
+      path.join('src', 'shared', 'timeseries', 'worker.js'),
+      [
+        '-d',
+        options.date,
+        '--findFeatures',
+        options.findFeatures,
+        '--findPopulations',
+        options.findPopulations,
+        '--writeData',
+        options.writeData
+      ],
+      {
+        stdio: ['ignore', 1, 2, 'ipc']
+      }
+    );
+
+    // Results are communicated back via an IPC message
+    child.on('message', resolve);
+
+    // If the child process closes without sending a message, something went wrong
+    child.on('close', reject);
+  });

--- a/src/shared/timeseries/runCrawler.js
+++ b/src/shared/timeseries/runCrawler.js
@@ -11,16 +11,11 @@ export default options =>
   new Promise((resolve, reject) => {
     const child = childProcess.fork(
       path.join('src', 'shared', 'timeseries', 'worker.js'),
-      [
-        '-d',
-        options.date,
-        '--findFeatures',
-        options.findFeatures,
-        '--findPopulations',
-        options.findPopulations,
-        '--writeData',
-        options.writeData
-      ],
+      // Pass options as arguments
+      Object.entries(options).reduce((args, entry) => {
+        args.push(`--${entry[0]}`, entry[1]);
+        return args;
+      }, []),
       {
         stdio: ['ignore', 1, 2, 'ipc']
       }

--- a/src/shared/timeseries/worker.js
+++ b/src/shared/timeseries/worker.js
@@ -1,0 +1,19 @@
+const imports = require('esm')(module);
+
+const generate = imports('../index.js').default;
+const argv = imports('../cli/cli-args.js').default;
+
+const clearAllTimeouts = imports('../utils/timeouts.js').default;
+
+generate(argv.date, argv)
+  .then(data => {
+    if (process.send) {
+      // Send data back to the parent process
+      process.send(data);
+    }
+  })
+  .then(clearAllTimeouts)
+  .catch(e => {
+    clearAllTimeouts();
+    throw e;
+  });


### PR DESCRIPTION
`yarn timeseries` has been running out of memory on many occasions. To prevent this from occurring, we can run the crawler in its own process. This PR adds a new function `runCrawler` which is called from `timeseries/index.js` and takes care of creating a child process and retrieving data from this process when crawling is done.