### PR TITLE
Add PR template, and multiple issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+
+# contact_links:
+#   - name: GitHub Community Forum
+#     url: https://github.community/
+#     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/data_issue.md
+++ b/.github/ISSUE_TEMPLATE/data_issue.md
@@ -1,0 +1,23 @@
+---
+name: Data issue
+about: Report a data issue
+title: SHORT_ISSUE_NAME for LOCATION on MM/DD
+labels: scraper, data issue
+assignees: ''
+
+---
+
+* **Source: ** [source or url, if applicable]
+* **File: ** [the data file with the discrepancy]
+* **Issue: ** [bad data or values currently in the file, and what was expected]
+
+```
+[If you can, please include a snippet of the file here, or a screenshot, so that the devs can search and find it quickly in the file.]
+```
+
+**Additional context**
+
+[Add any other context here.]
+
+
+<!--- Delete any section that doesn't apply.  Thank you! -->

--- a/.github/ISSUE_TEMPLATE/new-scraper.md
+++ b/.github/ISSUE_TEMPLATE/new-scraper.md
@@ -1,0 +1,16 @@
+---
+name: New scraper
+about: Add a new scraper
+title: Scraper for [LOCATION_HERE]
+labels: scraper
+assignees: ''
+
+---
+
+
+**The source**
+
+Please ensure the source meets our [source guidelines](../../tree/master/docs/sources.md#criteria-for-sources).  Thank you!
+
+* **Full location name: ** [Name here, e.g., "County x, CA, USA")]
+* **Source URL: ** [URL]

--- a/.github/ISSUE_TEMPLATE/report-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-bug.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Non-data issues
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Description**
+[A clear and concise description of what the bug is.]
+
+**To Reproduce**
+Steps to reproduce the behavior:
+[1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error]
+
+**Expected behavior**
+[A clear and concise description of what you expected to happen.]
+
+**Screenshots**
+[If applicable, add screenshots to help explain your problem.]
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+[Add any other context about the problem here.]
+
+
+<!--- Delete any section that doesn't apply.  Thank you very much! -->

--- a/.github/ISSUE_TEMPLATE/request-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-feature.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Description.
+
+[A clear and concise description of what the problem is. Ex. I'm
+always frustrated when ... / It would be great if ...]
+
+**Describe the solution you'd like**
+
+[A clear and concise description of what you want to happen.]
+
+**Describe alternatives you've considered**
+
+[A clear and concise description of any alternative solutions or
+features you've considered.]
+
+**Additional context**
+
+[Add any other context or screenshots about the feature request here.]
+
+
+<!--- Delete any section that doesn't apply.  Thank you very much! -->

--- a/.github/ISSUE_TEMPLATE/tech-debt.md
+++ b/.github/ISSUE_TEMPLATE/tech-debt.md
@@ -1,0 +1,22 @@
+---
+name: Tech debt
+about: (Devs/QA only) A change that would help us go harder/better/faster/stronger
+title: ''
+labels: tech debt
+assignees: ''
+
+---
+
+
+[Give a brief summary of the change you think we should implement.]
+
+* How will this make life better?
+* How big is this change (small/med/large/really large)? [Size]
+* How complicated is it? [Complexity]
+* What areas does it touch? [Affected areas]
+* What's the test plan? [Test plan]
+
+Demo/work-in-progress link: [If you have a demo or a branch with work-in-progress, link it here](my_branch_url)
+
+
+<!--- Delete any section that doesn't apply.  Thank you very much! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!---
+Hi there!  Some things to double-check prior to submission:
+
+- did you recently update this branch with upstream master,
+  to ensure everything works together?
+- did you `yarn lint` ?
+- did you `yarn test` ?
+- have you added any new tape tests to verify your change?
+- did you update any relevant documentation?
+
+Thanks very much!
+-->
+
+## Summary
+
+[What is this change about?  If it's related to an issue, please include the issue number (e.g., #426)]
+
+[Short description, before this change ...]
+
+[Short description, after this change ...]
+
+## Changes
+
+[Short summary of the code.  List major points, and refer to the lines in the diff as needed.]
+
+## Additional notes
+
+* what are success/failure conditions?
+* any side effects?
+
+
+<!-- You can erase any parts of this template if they're not applicable.  Cheers! -->


### PR DESCRIPTION
Some templates created after discussions today with @ryanblock and @lazd.  These files in .github pre-populate new issues and pull requests.  They are mostly regular yaml files, with some extra markup for issues at the top.

There are multiple issue templates, which I put together looking at the existing issues, and some other templates.  When you create a new issue, you're shown the below to pick the template you'll use:

![image](https://user-images.githubusercontent.com/1637133/78206346-d275c180-745b-11ea-99e4-31417307a97e.png)

The issues will have labels auto-assigned.

We can only have one PR template.  It has some comments at the top to remind people to do some things (run tests, lint, etc), and then has some standard questions.

When these files are present in the default branch (`master`), they'll become active.