### PR TITLE
add Recovered for AUS-SA

### DIFF
--- a/src/shared/scrapers/AUS/SA/index.js
+++ b/src/shared/scrapers/AUS/SA/index.js
@@ -4,7 +4,12 @@ import * as parse from '../../../lib/parse.js';
 import getKey from '../_shared/get-key.js';
 import maintainers from '../../../lib/maintainers.js';
 
-const labelFragmentsByKey = [{ cases: 'confirmed case' }, { hospitalized: 'icu' }, { deaths: 'deaths' }];
+const labelFragmentsByKey = [
+  { cases: 'confirmed case' },
+  { deaths: 'deaths' },
+  { hospitalized: 'icu' },
+  { recovered: 'cases cleared' }
+];
 
 const scraper = {
   country: 'AUS',


### PR DESCRIPTION
## Summary

South Australia added a table row, which throws an Error that we noticed in the scraper report. Now we have a recovered count, just a tested count still to go if they ever add it.
This is a backwards compatible change.