### PR TITLE
Fix scraping of JHU 'recovered' data

### DIFF
--- a/src/shared/scrapers/JHU.js
+++ b/src/shared/scrapers/JHU.js
@@ -294,12 +294,11 @@ const scraper = {
             country: 'USA',
             state,
             cases: parse.number(cases[index][date] || 0),
-            deaths: parse.number(deaths[index][date] || 0),
-            recovered: parse.number(recoveredData[date] || 0)
+            deaths: parse.number(deaths[index][date] || 0)
           };
 
           if (recoveredData) {
-            const recoveredCount = recoveredData[datetime.getMDYYYY(date)];
+            const recoveredCount = recoveredData[date];
             if (recoveredCount !== undefined) {
               caseData.recovered = parse.number(recoveredCount);
             }
@@ -316,7 +315,7 @@ const scraper = {
           };
 
           if (recoveredData) {
-            const recoveredCount = recoveredData[datetime.getMDYYYY(date)];
+            const recoveredCount = recoveredData[date];
             if (recoveredCount !== undefined) {
               caseData.recovered = parse.number(recoveredCount);
             }

--- a/src/shared/scrapers/JHU.js
+++ b/src/shared/scrapers/JHU.js
@@ -283,29 +283,7 @@ const scraper = {
           cases[index]['Province/State'] = '';
         }
 
-        // Use their US states
-        if (
-          cases[index]['Country/Region'] === 'US' &&
-          geography.usStates[parse.string(cases[index]['Province/State'] || '')]
-        ) {
-          const state = geography.usStates[parse.string(cases[index]['Province/State'])];
-          const caseData = {
-            aggregate: 'state',
-            country: 'USA',
-            state,
-            cases: parse.number(cases[index][date] || 0),
-            deaths: parse.number(deaths[index][date] || 0)
-          };
-
-          if (recoveredData) {
-            const recoveredCount = recoveredData[date];
-            if (recoveredCount !== undefined) {
-              caseData.recovered = parse.number(recoveredCount);
-            }
-          }
-
-          countries.push(caseData);
-        } else if (rules.isAcceptable(cases[index], this._accept, this._reject)) {
+        if (rules.isAcceptable(cases[index], this._accept, this._reject)) {
           const caseData = {
             aggregate: 'country',
             country: parse.string(cases[index]['Country/Region']),


### PR DESCRIPTION
Note the 'US' conditional branch is never hit there because of
the lack of US states in the global data (separate issue).

Closes #618