### PR TITLE
Scraper 599

### DIFF
--- a/src/shared/lib/maintainers.js
+++ b/src/shared/lib/maintainers.js
@@ -48,6 +48,15 @@ const maintainers = {
     name: 'Quentin Golsteyn',
     github: 'qgolsteyn',
     flag: '🇨🇦'
+  },
+  slezakbs: {
+    name: 'Brendan Slezak',
+    email: 'brendan.slezak@geospark.io',
+    github: 'slezakbs',
+    country: 'US',
+    state: 'VA',
+    city: 'Richmond',
+    flag: '🇺🇸'
   }
 };
 

--- a/src/shared/scrapers/USA/MO/index.js
+++ b/src/shared/scrapers/USA/MO/index.js
@@ -284,7 +284,7 @@ const scraper = {
             counties[countyName] = {
               cases: parse.number(countyData.Cases || 0),
               deaths: parse.number(countyData.Deaths || 0),
-              updatedDate: countyData.EditDate
+              publishedDate: countyData.EditDate
             };
           }
         }

--- a/src/shared/scrapers/USA/MO/index.js
+++ b/src/shared/scrapers/USA/MO/index.js
@@ -36,8 +36,7 @@ const scraper = {
     'Ste Genevieve': 'Ste. Genevieve County',
     'St Francois': 'St. Francois County',
     Joplin: 'Jasper County',
-    'St Louis City': 'St. Louis County',
-    'St. Louis City': 'St. Louis County'
+    'St Louis City': 'St. Louis City'
   },
   _counties: [
     'Adair County',
@@ -135,6 +134,7 @@ const scraper = {
     'St. Clair County',
     'St. Francois County',
     'St. Louis County',
+    'St. Louis City',
     'Ste. Genevieve County',
     'Saline County',
     'Schuyler County',
@@ -274,8 +274,9 @@ const scraper = {
           unassigned.cases += parse.number(countyData.Cases || 0);
           unassigned.deaths += parse.number(countyData.Deaths || 0);
         } else {
-          countyName = geography.addCounty(countyName);
-
+          if(countyName.toUpperCase().indexOf(" CITY") === -1){
+            countyName = geography.addCounty(countyName);
+          }
           if (countyName in counties) {
             counties[countyName].cases += parse.number(countyData.Cases || 0);
             counties[countyName].deaths += parse.number(countyData.Deaths || 0);

--- a/src/shared/scrapers/USA/MO/index.js
+++ b/src/shared/scrapers/USA/MO/index.js
@@ -274,7 +274,7 @@ const scraper = {
           unassigned.cases += parse.number(countyData.Cases || 0);
           unassigned.deaths += parse.number(countyData.Deaths || 0);
         } else {
-          if(countyName.toUpperCase().indexOf(" CITY") === -1){
+          if (countyName.toUpperCase().indexOf(' CITY') === -1) {
             countyName = geography.addCounty(countyName);
           }
           if (countyName in counties) {

--- a/src/shared/scrapers/USA/MO/index.js
+++ b/src/shared/scrapers/USA/MO/index.js
@@ -283,7 +283,8 @@ const scraper = {
           } else {
             counties[countyName] = {
               cases: parse.number(countyData.Cases || 0),
-              deaths: parse.number(countyData.Deaths || 0)
+              deaths: parse.number(countyData.Deaths || 0),
+              updatedDate: countyData.EditDate
             };
           }
         }

--- a/src/shared/scrapers/USA/MO/st-louis-county.js
+++ b/src/shared/scrapers/USA/MO/st-louis-county.js
@@ -27,7 +27,8 @@ const scraper = {
       county: geography.addCounty(this.county),
       cases: parse.number(data.Cumulative_Cases),
       deaths: parse.number(data.Deaths),
-      recovered: parse.number(data.Cases_Recovered)
+      recovered: parse.number(data.Cases_Recovered),
+      updatedDate: data.edit_date
     };
   }
 };

--- a/src/shared/scrapers/USA/MO/st-louis-county.js
+++ b/src/shared/scrapers/USA/MO/st-louis-county.js
@@ -1,0 +1,37 @@
+import * as fetch from '../../../lib/fetch/index.js';
+import * as parse from '../../../lib/parse.js';
+import maintainers from '../../../lib/maintainers.js';
+import * as geography from "../../../lib/geography";
+
+const scraper = {
+  county: 'St. Louis County',
+  state: 'MO',
+  country: 'USA',
+  aggregate: 'county',
+  priority: 1,
+  sources: [
+    {
+      url: 'https://stlouisco.com/Your-Government/County-Executive/COVID-19',
+      name: 'St. Louis County COVID-19 page'
+    }
+  ],
+  url: 'https://stlcogis.maps.arcgis.com/apps/MapSeries/index.html?appid=6ae65dea4d804f2ea4f5d8ba79e96df1',
+  headless: true,
+  type: 'table',
+  maintainers: [maintainers.slezakbs],
+  async scraper() {
+    this.url = await fetch.getArcGISCSVURLFromOrgId(2, 'w657bnjzrjguNyOy', 'StLouisCounty_Bdy_Geo');
+    const data = await fetch.csv(this.url);
+    if (data.length === 1) {
+      return {
+        county: geography.addCounty(this.county),
+        cases: parse.number(data[0]['Cumulative_Cases']),
+        deaths: parse.number(data[0]['Deaths']),
+        recovered: parse.number(data[0]['Cases_Recovered'])
+      }
+    } else {
+      return {};
+    }
+  }
+};
+export default scraper;

--- a/src/shared/scrapers/USA/MO/st-louis-county.js
+++ b/src/shared/scrapers/USA/MO/st-louis-county.js
@@ -1,7 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
-import * as geography from "../../../lib/geography";
+import * as geography from '../../../lib/geography/index.js';
 
 const scraper = {
   county: 'St. Louis County',
@@ -21,17 +21,14 @@ const scraper = {
   maintainers: [maintainers.slezakbs],
   async scraper() {
     this.url = await fetch.getArcGISCSVURLFromOrgId(2, 'w657bnjzrjguNyOy', 'StLouisCounty_Bdy_Geo');
-    const data = await fetch.csv(this.url);
-    if (data.length === 1) {
-      return {
-        county: geography.addCounty(this.county),
-        cases: parse.number(data[0]['Cumulative_Cases']),
-        deaths: parse.number(data[0]['Deaths']),
-        recovered: parse.number(data[0]['Cases_Recovered'])
-      }
-    } else {
-      return {};
-    }
+    const rows = await fetch.csv(this.url);
+    const data = rows[0];
+    return {
+      county: geography.addCounty(this.county),
+      cases: parse.number(data.Cumulative_Cases),
+      deaths: parse.number(data.Deaths),
+      recovered: parse.number(data.Cases_Recovered)
+    };
   }
 };
 export default scraper;

--- a/src/shared/scrapers/USA/MO/st-louis-county.js
+++ b/src/shared/scrapers/USA/MO/st-louis-county.js
@@ -28,7 +28,7 @@ const scraper = {
       cases: parse.number(data.Cumulative_Cases),
       deaths: parse.number(data.Deaths),
       recovered: parse.number(data.Cases_Recovered),
-      updatedDate: data.edit_date
+      publishedDate: data.edit_date
     };
   }
 };


### PR DESCRIPTION
## Summary
Fixes issue #599 

St. Louis County is posting most recent changes in cases on county page: https://stlouisco.com/Your-Government/County-Executive/COVID-19
Numbers from MO Health Dept have a delay.

## Changes
*  Scrape case numbers for St. Louis County directly from linked ArcGIS map from county website.
*  No longer combining St. Louis County cases with St. Louis City

## Additional notes

Please note, before this change we were merging case numbers of St. Louis City with St. Louis County.  I'm not sure what the reasoning was originally, but as a user of the source code I would personally prefer to keep them separate since we seem to separate city/county for other areas, such as my home town Richmond City vs Richmond County.


