### PR TITLE
Unit tests: Verify scraper schema

### DIFF
--- a/tests/unit/shared/scrapers/scrapers-all-test.js
+++ b/tests/unit/shared/scrapers/scrapers-all-test.js
@@ -1,0 +1,37 @@
+const imports = require('esm')(module);
+const { join } = require('path');
+const test = require('tape');
+const fastGlob = require('fast-glob');
+const path = require('path');
+const shared = join(process.cwd(), 'src', 'shared');
+const lib = join(shared, 'lib');
+const schema = imports(join(lib, 'schema.js'));
+const fs = imports(join(lib, 'fs.js'));
+
+const scraperRoot = join(shared, 'scrapers');
+
+// Ignore any files or subdirectory in scrapers that starts with _
+const ignoreUnderscoreFiles = /(\/|\\)_/
+
+const scraperFiles =  fastGlob.sync(join(scraperRoot, '**', '*.js'))
+   .filter(f => !ignoreUnderscoreFiles.test(f));
+
+const scrapers = scraperFiles.map(f => {
+  const scraperName = f.replace(scraperRoot, '');
+  const scraperObj = imports(f).default;
+  return {
+    name: scraperName,
+    scraperObj
+  };
+});
+
+
+test('srapers-all-test: all scraper schema', async t => {
+  t.plan(scrapers.length);
+  for (const s of scrapers) {
+    const hasErrors = schema.schemaHasErrors(s.scraperObj, schema.schemas.scraperSchema);
+    t.notOk(hasErrors, `${s.name} schema ok`);
+  }
+  t.end();
+});
+

--- a/tests/unit/shared/scrapers/scrapers-all-test.js
+++ b/tests/unit/shared/scrapers/scrapers-all-test.js
@@ -2,29 +2,25 @@ const imports = require('esm')(module);
 const { join } = require('path');
 const test = require('tape');
 const fastGlob = require('fast-glob');
-const path = require('path');
+
 const shared = join(process.cwd(), 'src', 'shared');
 const lib = join(shared, 'lib');
 const schema = imports(join(lib, 'schema.js'));
-const fs = imports(join(lib, 'fs.js'));
 
 const scraperRoot = join(shared, 'scrapers');
 
-// Ignore any files or subdirectory in scrapers that starts with _
-const ignoreUnderscoreFiles = /(\/|\\)_/
+const allJs = fastGlob.sync(join(scraperRoot, '**', '*.js'));
 
-const scraperFiles =  fastGlob.sync(join(scraperRoot, '**', '*.js'))
-   .filter(f => !ignoreUnderscoreFiles.test(f));
+// Ignore any files or subdirectory in scrapers that starts with _
+const ignoreUnderscoreFiles = /(\/|\\)_/;
+const scraperFiles = allJs.filter(f => !ignoreUnderscoreFiles.test(f));
 
 const scrapers = scraperFiles.map(f => {
-  const scraperName = f.replace(scraperRoot, '');
-  const scraperObj = imports(f).default;
   return {
-    name: scraperName,
-    scraperObj
+    name: f.replace(scraperRoot, ''),
+    scraperObj: imports(f).default
   };
 });
-
 
 test('srapers-all-test: all scraper schema', async t => {
   t.plan(scrapers.length);
@@ -34,4 +30,3 @@ test('srapers-all-test: all scraper schema', async t => {
   }
   t.end();
 });
-

--- a/tests/unit/shared/scrapers/scrapers-all-test.js
+++ b/tests/unit/shared/scrapers/scrapers-all-test.js
@@ -22,7 +22,7 @@ const scrapers = scraperFiles.map(f => {
   };
 });
 
-test('srapers-all-test: all scraper schema', async t => {
+test('scrapers-all-test: all scraper schema', async t => {
   t.plan(scrapers.length);
   for (const s of scrapers) {
     const hasErrors = schema.schemaHasErrors(s.scraperObj, schema.schemas.scraperSchema);


### PR DESCRIPTION
## Summary

Addresses #604 

Adds tests for all scraper files (all `*.js` files in `src/shared/scrapers`, excluding files or folders that start with underscore.  Provides the collection of scraper objects so that additional tests for all scrapers can be added, if needed.

Sample test spec output:

```
  srapers-all-test: all scraper schema

     /JHU.js schema ok
     /AUS/index.js schema ok
     /BRA/index.js schema ok
     /CAN/index.js schema ok
    ... etc.
```

These tests run with the unit tests, `yarn test`.  It appears to take a moment to load all of the files, but still super fast.