### PR TITLE
scrape NSW AU deaths from paragraphs where possible

### DIFF
--- a/src/shared/scrapers/AUS/NSW/index.js
+++ b/src/shared/scrapers/AUS/NSW/index.js
@@ -7,6 +7,16 @@ import maintainers from '../../../lib/maintainers.js';
 
 const labelFragmentsByKey = [{ cases: 'confirmed case' }, { testedNegative: 'tested and excluded' }];
 
+const getDeathsFromParagraph = $currentArticlePage => {
+  const paragraph = $currentArticlePage('p:contains("deaths")').text();
+  const matches = paragraph.match(/been (?<casesString>[\d,]+) deaths/) || {};
+  const { casesString } = matches.groups || {};
+  if (casesString && parse.number(casesString) > 0) {
+    return parse.number(casesString);
+  }
+  return undefined;
+};
+
 const scraper = {
   country: 'AUS',
   maintainer: [maintainers.camjc],
@@ -37,6 +47,7 @@ const scraper = {
       data[key] = parse.number($tr.find('td:last-child').text());
     });
     assert(data.cases > 0, 'Cases is not reasonable');
+    data.deaths = getDeathsFromParagraph($currentArticlePage);
     return getDataWithTestedNegativeApplied(data);
   }
 };


### PR DESCRIPTION
Looks like NSW is following a pretty consistent format for deaths, so lets add that data where we can.