### PR TITLE
Add onlyUseCache command-line flag

### DIFF
--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -54,6 +54,7 @@ const { argv } = yargs
     type: 'boolean'
   })
   .option('onlyUseCache', {
+    alias: 'x',
     description: 'Only use cache (no http calls)',
     type: 'boolean'
   })

--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -56,4 +56,14 @@ const { argv } = yargs
   .help()
   .alias('help', 'h');
 
+if (argv.date) {
+  process.env.SCRAPE_DATE = argv.date;
+} else {
+  delete process.env.SCRAPE_DATE;
+}
+
+if (argv.quiet) {
+  process.env.LOG_LEVEL = 'off';
+}
+
 export default argv;

--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -53,6 +53,10 @@ const { argv } = yargs
     description: 'Write to dist folder',
     type: 'boolean'
   })
+  .option('onlyUseCache', {
+    description: 'Only use cache (no http calls)',
+    type: 'boolean'
+  })
   .help()
   .alias('help', 'h');
 
@@ -64,6 +68,12 @@ if (argv.date) {
 
 if (argv.quiet) {
   process.env.LOG_LEVEL = 'off';
+}
+
+if (argv.onlyUseCache) {
+  process.env.ONLY_USE_CACHE = true;
+} else {
+  delete process.env.ONLY_USE_CACHE;
 }
 
 export default argv;

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -17,17 +17,8 @@ import datetime from './lib/datetime/index.js';
  * Entry file while we're still hosted on GitHub
  */
 async function generate(date, options = {}) {
+
   options = { findFeatures: true, findPopulations: true, writeData: true, ...options };
-
-  if (date) {
-    process.env.SCRAPE_DATE = date;
-  } else {
-    delete process.env.SCRAPE_DATE;
-  }
-
-  if (options.quiet) {
-    process.env.LOG_LEVEL = 'off';
-  }
 
   // JSON used for reporting
   const report = {

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -17,7 +17,6 @@ import datetime from './lib/datetime/index.js';
  * Entry file while we're still hosted on GitHub
  */
 async function generate(date, options = {}) {
-
   options = { findFeatures: true, findPopulations: true, writeData: true, ...options };
 
   // JSON used for reporting

--- a/src/shared/lib/fetch/get.js
+++ b/src/shared/lib/fetch/get.js
@@ -43,8 +43,7 @@ export const get = async (url, type, date = datetime.old.scrapeDate() || datetim
   };
 
   const cachedBody = await caching.getCachedFile(url, type, date, encoding);
-  if (process.env.ONLY_USE_CACHE)
-    return cachedBody;
+  if (process.env.ONLY_USE_CACHE) return cachedBody;
 
   if (cachedBody === caching.CACHE_MISS || alwaysRun) {
     log('  🚦  Loading data for %s from server', url);

--- a/src/shared/lib/fetch/get.js
+++ b/src/shared/lib/fetch/get.js
@@ -43,6 +43,8 @@ export const get = async (url, type, date = datetime.old.scrapeDate() || datetim
   };
 
   const cachedBody = await caching.getCachedFile(url, type, date, encoding);
+  if (process.env.ONLY_USE_CACHE)
+    return cachedBody;
 
   if (cachedBody === caching.CACHE_MISS || alwaysRun) {
     log('  🚦  Loading data for %s from server', url);

--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -193,6 +193,8 @@ export const headless = async (url, date = datetime.old.scrapeDate() || datetime
   const { alwaysRun } = { alwaysRun: false, disableSSL: false, ...options };
 
   const cachedBody = await caching.getCachedFile(url, 'html', date);
+  if (process.env.ONLY_USE_CACHE)
+    return await cheerio.load(cachedBody);
 
   if (cachedBody === caching.CACHE_MISS || alwaysRun) {
     const fetchedBody = await fetchHeadless(url);

--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -193,8 +193,10 @@ export const headless = async (url, date = datetime.old.scrapeDate() || datetime
   const { alwaysRun } = { alwaysRun: false, disableSSL: false, ...options };
 
   const cachedBody = await caching.getCachedFile(url, 'html', date);
-  if (process.env.ONLY_USE_CACHE)
-    return await cheerio.load(cachedBody);
+  if (process.env.ONLY_USE_CACHE) {
+    const $ = await cheerio.load(cachedBody);
+    return $;
+  }
 
   if (cachedBody === caching.CACHE_MISS || alwaysRun) {
     const fetchedBody = await fetchHeadless(url);


### PR DESCRIPTION
## Summary

(Code salvaged from Herb C's PR #580.)

Adds `--onlyUseCache`, to ensure that we stick with cache!

This change opens up the possibility for testing things entirely offline.  If a cache misses, it returns null, and then scrapers have to deal with that.

## Sample run

```
$ yarn start --location "PA, USA" --onlyUseCache -d 2020-04-04
yarn run v1.22.4
$ node src/shared/cli/index.js --location 'PA, USA' --onlyUseCache -d 2020-04-04
⏳ Fetching scrapers...
✅ Fetched 135 scrapers!
✅ All scrapers are valid!
  🐢  Cache miss for https://www.health.pa.gov/topics/disease/coronavirus/Pages/Cases.aspx at coronadatascraper-cache/2020-4-4/6847ef86804ff0c3c03f31ca00d7eb6d.html
  ❌ Error processing PA, USA:  TypeError: $ is not a function
    at Object.scraper (/Users/jeff/Documents/Projects/coronadatascraper/src/shared/scrapers/USA/PA/index.js:181:28)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async runScrapers ...

```

The `TypeError: $ is not a function` is how this scraper deals with a cache miss, and failed fetches.

## Additional notes

* This introduces more global state, but it's probably OK.  I need to open a separate PR to deal with global state during testing.
* I have only tested this and verified manually, I'm not sure how to test this with JS at the moment given the global state issue.  (If I write a simple test with this, it could break other tests referring to the global state.)  I could potentially write a bash script or something that gets called in its own CI step and process, but wasn't sure how to fit that within the project coding style.

## Further thoughts

Could this be used to diagnose how scrapers handle cache misses and empty returns?  They should all throw better messages, not nonsense like `$ is not a function`.