### PR TITLE
fix: Make countries human readable (#647)

### DIFF
--- a/src/events/processor/transform-ids/index.js
+++ b/src/events/processor/transform-ids/index.js
@@ -1,6 +1,7 @@
 import * as countryLevels from '../../../shared/lib/geography/country-levels.js';
 import * as geography from '../../../shared/lib/geography/index.js';
 import log from '../../../shared/lib/log.js';
+import countryCodes from '../../../shared/vendor/country-codes.json';
 
 const transformIds = async ({ locations, featureCollection, report, options, sourceRatings }) => {
   log('⏳ Transforming IDs...');
@@ -11,6 +12,18 @@ const transformIds = async ({ locations, featureCollection, report, options, sou
     if (clId) {
       idsFound++;
       await countryLevels.transformLocationIds(location);
+    }
+    // Transform countries that are in alpha-3 format that were not transformed above
+    const { country } = location;
+    if (country && !location.countryId) {
+      const countryCode = countryCodes.find(x => x['alpha-3'] === country);
+      if (countryCode) {
+        location.countryID = country;
+        location.country = countryCode.name;
+        if (!clId) {
+          idsFound++;
+        }
+      }
     }
 
     if (!location.name) {


### PR DESCRIPTION
## Summary

Make countries human readable (#647)

Before this change, countries other than United States were shown in the data reports using their alpha-3 code. Now they use the full, human readable name.

![image](https://user-images.githubusercontent.com/26416783/78465276-2b8e6100-76b9-11ea-88dd-0f8684ac263d.png)

## Changes

Changed the transformIds function to transform alpha-3 country codes. The function was previously only relying on countryLevels.transformLocationIds, which does not recognize alpha-3 country codes.

## Additional notes

Unfortunately this does not fix the cross check report - the locations there are still not human readable. This would require more work, likely moving the transformIds function to run before the dedupeLocations function, and modifying the findFeatures and findPopulations functions to work with the transformed ids (perhaps by using the id fields like countryId instead of fields like country).