### PR TITLE
fixed the table-name in IND scraper

### DIFF
--- a/src/shared/scrapers/IND/index.js
+++ b/src/shared/scrapers/IND/index.js
@@ -17,7 +17,7 @@ const scraper = {
     this.url = 'https://www.mohfw.gov.in/';
     const $ = await fetch.page(this.url);
 
-    const $table = $('#cases table');
+    const $table = $('#state-data');
     const $trs = $table.find('tbody > tr');
     const regions = [];
 


### PR DESCRIPTION
<!---
Hi there!  Some things to double-check prior to submission:

- did you recently update this branch with upstream master,
  to ensure everything works together?
Yes
- did you `yarn lint` ?
Yes
- did you `yarn test` ?
Yes
- have you added any new tape tests to verify your change?
New test case not applicable. Just changed the name of the table scraped IND region.
- did you update any relevant documentation?
N/A
-->

## Summary

<!-- What is this change about?  If it's related to an issue, please include the issue number (e.g., #426) -->
#654 - The previous version of the scraper was not using the right table name to access the data. Just change the table name.

<!-- Short description, before this change ... -->
The previous version of the scraper was not using the right table name to access the data. Just change the table name.

<!-- Short description, after this change ... -->

## Changes

<!-- Short summary of the code.  List major points, and refer to the lines in the diff as needed. -->
    
//    const $table = $('#cases table');
    const $table = $('#state-data');
changed the name of the table reference from "cases table" to "state-data"

## Additional notes

<!--
  * mention any test coverage added or changed
  * what are success/failure conditions?
  * are there any side effects?
-->
Does not impact the coverage.
This should not break again so long as the table name is not changed.

<!-- Erase any parts of this template if they're not applicable.  Cheers! -->
