### PR TITLE
Change the caching strategy of geo-tz library

### DIFF
--- a/src/events/processor/find-features/index.js
+++ b/src/events/processor/find-features/index.js
@@ -10,6 +10,10 @@ import espGeoJson from '../vendor/esp.json';
 
 const DEBUG = false;
 
+// sets the caching strategy of the geo-tz library to store data in memory
+// without an expiring timeout
+geoTz.setCache({ expires: 0 });
+
 function cleanProps(obj) {
   if (obj.wikipedia === -99) {
     delete obj.wikipedia;

--- a/src/shared/utils/timeouts.js
+++ b/src/shared/utils/timeouts.js
@@ -1,7 +1,7 @@
 /**
- * Some libraries in this project have gone rogue and decided to include timeouts,
- * (looking at you, geo-tz) meaning Node will not exit after the scraper has finished running. This file
- * allows us to clear all timeouts on exit.
+ * Some libraries in this project include timeouts, meaning Node will not exit
+ * after the scraper has finished running. This file allows us to clear all
+ * timeouts on exit.
  */
 
 const globalObject = global;


### PR DESCRIPTION
This changes the caching strategy of the geo-tz library so that data is stored in-memory rather than using the timed-cache library which will result in no timeouts being applied to the data. Also, a comment has been rewritten to not call out the geo-tz library specifically.