### PR TITLE
[patch] support deaths in table now, backwards compatible

### DIFF
--- a/src/shared/scrapers/AU/NSW/index.js
+++ b/src/shared/scrapers/AU/NSW/index.js
@@ -5,7 +5,11 @@ import getDataWithTestedNegativeApplied from '../_shared/get-data-with-tested-ne
 import getKey from '../../../utils/get-key.js';
 import maintainers from '../../../lib/maintainers.js';
 
-const labelFragmentsByKey = [{ cases: 'confirmed case' }, { testedNegative: 'tested and excluded' }];
+const labelFragmentsByKey = [
+  { deaths: 'deaths' },
+  { cases: 'confirmed case' },
+  { testedNegative: 'tested and excluded' }
+];
 
 const getDeathsFromParagraph = $currentArticlePage => {
   const paragraph = $currentArticlePage('p:contains("deaths")').text();
@@ -47,7 +51,7 @@ const scraper = {
       data[key] = parse.number($tr.find('td:last-child').text());
     });
     assert(data.cases > 0, 'Cases is not reasonable');
-    data.deaths = getDeathsFromParagraph($currentArticlePage);
+    data.deaths = data.deaths || getDeathsFromParagraph($currentArticlePage);
     return getDataWithTestedNegativeApplied(data);
   }
 };


### PR DESCRIPTION
They have 'confirmed cases' in their deaths row as a parenthetical, so the unknown row assertion didn't trigger, haha.
<img width="718" alt="image" src="https://user-images.githubusercontent.com/4197647/78734682-3df3ed80-798c-11ea-8237-f961747f1e8d.png">

Keep the paragraph scraper as a fallback for backwards compatibility.