### PR TITLE
Fix command line scraper filters

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -70,9 +70,9 @@ To run the scrapers for today:
 yarn start
 ```
 
-### Run scrapers for only one location
+### Run selected scrapers
 
-To scrape just one location, use `--location`/`-l`
+To use a subset of scrapers, use `--location`/`-l`
 
 ```
 yarn start --location "US/PA"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -82,9 +82,11 @@ The `location` value should match a path under `src/shared/scrapers/`.
 
 Examples:
 
-* `US`: run all U.S. scrapers
-* `US/CA`: run all California scrapers
-* `US/CA/alameda-county.js`: run this single scraper
+* `yarn start --location "US"`: run all scrapers in `src/shared/scrapers/US` and child folders
+* `yarn start --location "US/CA"`: run all scrapers in `src/shared/scrapers/US/CA` and child folders
+* `yarn start --location "US/CA/alameda-county.js"`: run this single scraper
+* `yarn start --location "AU"`: run all scrapers in `src/shared/scrapers/AU` and child folders
+* `yarn start --location "AU/index.js"`: run this single scraper
 
 
 ### Skipping a scraper

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -43,7 +43,7 @@ If you get an error message saying you have an incompatible version of
 node versions: [install](https://www.npmjs.com/package/n) it and run
 `n lts`.
 
-### 3. Run the scraper
+### 3. Run the scrapers
 
 ```
 yarn start
@@ -70,26 +70,29 @@ To run the scrapers for today:
 yarn start
 ```
 
-### Run only one scraper
+### Run scrapers for only one location
 
 To scrape just one location, use `--location`/`-l`
 
 ```
-yarn start --location "Ventura County, CA, USA"
+yarn start --location "US/PA"
 ```
 
-Alternatively, you can pass a filename (without extension or directory name) to `--location`:
+The `location` value should match a path under `src/shared/scrapers/`.
 
-```
-yarn start --location "JHU"
-```
+Examples:
+
+* `US`: run all U.S. scrapers
+* `US/CA`: run all California scrapers
+* `US/CA/alameda-county.js`: run this single scraper
+
 
 ### Skipping a scraper
 
 To skip a scraper, use `--skip`/`-s`
 
 ```
-yarn start --skip "Ventura County, CA, USA"
+yarn start --skip "US/CA/alameda-county.js"
 ```
 
 ### Re-generating old data

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -426,7 +426,11 @@ a file with the name `expected.YYYY-MM-DD.json`; for example, `expected.2020-03-
 
 ### Manual testing
 
-You should run your source with the crawler by running `yarn start -l "<name of your source>"`. Your source name will be as follow "<county name>, <state name>, <country name>" (eg., the scraper for Montana, USA is "MN, USA").
+You should run your source with the crawler by running `yarn start -l "<path to scraper>"`.
+
+The path to scraper should be the relative path under
+`src/shared/scrapers`; e.g., the scraper for Montana, USA would be
+"US/MO").
 
 After the crawler has finished running, look at how many counties, states, and countries were
 scraped. Also look for missing location or population information. Finally, look at the output located in the `dist` directory. `data.json` contains all the information

--- a/src/events/crawler/get-sources/load-sources.js
+++ b/src/events/crawler/get-sources/load-sources.js
@@ -1,7 +1,7 @@
 import fastGlob from 'fast-glob';
 import join from '../../../shared/lib/join.js';
 import log from '../../../shared/lib/log.js';
-import * as countryLevels from  '../../../shared/lib/geography/country-levels.js';
+import * as countryLevels from '../../../shared/lib/geography/country-levels.js';
 
 /** Check location inclusion, based on command-line options.
  * (*) location - the location
@@ -32,8 +32,7 @@ export default async args => {
   filePaths = filePaths.filter(file => file.match(/scrapers(?![^/])(?!.*\/_).*\.js$/gi));
 
   // eslint-disable-next-line
-  const sources = await Promise.all(
-    filePaths.map(filePath => require(filePath)))
+  const sources = await Promise.all(filePaths.map(filePath => require(filePath)))
         .then(modules => [
     ...modules.map((module, index) => ({ _path: filePaths[index], ...module.default }))
   ]);

--- a/src/events/crawler/get-sources/load-sources.js
+++ b/src/events/crawler/get-sources/load-sources.js
@@ -1,7 +1,6 @@
 import fastGlob from 'fast-glob';
 import join from '../../../shared/lib/join.js';
 import log from '../../../shared/lib/log.js';
-import * as countryLevels from '../../../shared/lib/geography/country-levels.js';
 
 /** Check location inclusion, based on command-line options.
  * (*) location - the location
@@ -13,10 +12,6 @@ function includeLocation(location, opts) {
   if (opts.skip && relpath.startsWith(opts.skip)) return false;
 
   if (opts.location && !relpath.startsWith(opts.location)) return false;
-
-  // select location based on country level id
-  // for example "yarn start -i id3:AU-VIC"
-  if (opts.id && opts.id !== countryLevels.getIdFromLocation(location)) return false;
 
   return true;
 }

--- a/src/events/crawler/get-sources/load-sources.js
+++ b/src/events/crawler/get-sources/load-sources.js
@@ -1,8 +1,7 @@
 import fastGlob from 'fast-glob';
-import path from 'path';
 import join from '../../../shared/lib/join.js';
 import log from '../../../shared/lib/log.js';
-import * as geography from '../../../shared/lib/geography/index.js';
+import * as countryLevels from  '../../../shared/lib/geography/country-levels.js';
 
 /** Check location inclusion, based on command-line options.
  * (*) location - the location
@@ -11,20 +10,16 @@ import * as geography from '../../../shared/lib/geography/index.js';
 function includeLocation(location, opts) {
   const relpath = location._path.replace(/.*?src.shared.scrapers./, '');
 
-  if (opts.skip && relpath.startsWith(opts.skip))
-    return false;
+  if (opts.skip && relpath.startsWith(opts.skip)) return false;
 
-  if (opts.location && !relpath.startsWith(opts.location))
-    return false;
+  if (opts.location && !relpath.startsWith(opts.location)) return false;
 
   // select location based on country level id
   // for example "yarn start -i id3:AU-VIC"
-  if (opts.id && opts.id !== countryLevels.getIdFromLocation(location))
-    return false;
+  if (opts.id && opts.id !== countryLevels.getIdFromLocation(location)) return false;
 
   return true;
 }
-
 
 export default async args => {
   log(`⏳ Fetching scrapers...`);
@@ -40,7 +35,8 @@ export default async args => {
   const sources = await Promise.all(
     filePaths.map(filePath => require(filePath)))
         .then(modules => [
-          ...modules.map((module, index) => ({ _path: filePaths[index], ...module.default }))]);
+    ...modules.map((module, index) => ({ _path: filePaths[index], ...module.default }))
+  ]);
   const filteredSources = sources.filter(m => includeLocation(m, args.options));
 
   if (filteredSources.length === 0) {
@@ -50,8 +46,6 @@ export default async args => {
   } else {
     log(`✅ Fetched ${sources.length} scrapers.`);
   }
-  
-
 
   return { ...args, sources: filteredSources };
 };

--- a/src/events/crawler/get-sources/load-sources.js
+++ b/src/events/crawler/get-sources/load-sources.js
@@ -4,28 +4,25 @@ import join from '../../../shared/lib/join.js';
 import log from '../../../shared/lib/log.js';
 import * as geography from '../../../shared/lib/geography/index.js';
 
-/** Check location inclusion, based on args. */
-function includeLocation(location, options) {
+/** Check location inclusion, based on command-line options.
+ * (*) location - the location
+ * (*) opts - options
+ */
+function includeLocation(location, opts) {
+  const relpath = location._path.replace(/.*?src.shared.scrapers./, '');
 
-  if (options.skip && geography.getName(location) === options.skip)
+  if (opts.skip && relpath.startsWith(opts.skip))
     return false;
 
-    if (
-      options.location &&
-        path.basename(location._path, '.js') !== options.location &&
-        geography.getName(location) !== options.location
-    )
-      return false;
+  if (opts.location && !relpath.startsWith(opts.location))
+    return false;
 
-    if (options.country && ![options.country, `iso1:${options.country}`].includes(location.country))
-      return false;
+  // select location based on country level id
+  // for example "yarn start -i id3:AU-VIC"
+  if (opts.id && opts.id !== countryLevels.getIdFromLocation(location))
+    return false;
 
-    // select location based on country level id
-    // for example "yarn start -i id3:AU-VIC"
-    if (options.id && options.id !== countryLevels.getIdFromLocation(location))
-      return false;
-
-    return true;
+  return true;
 }
 
 

--- a/src/events/crawler/get-sources/load-sources.js
+++ b/src/events/crawler/get-sources/load-sources.js
@@ -1,6 +1,33 @@
 import fastGlob from 'fast-glob';
+import path from 'path';
 import join from '../../../shared/lib/join.js';
 import log from '../../../shared/lib/log.js';
+import * as geography from '../../../shared/lib/geography/index.js';
+
+/** Check location inclusion, based on args. */
+function includeLocation(location, options) {
+
+  if (options.skip && geography.getName(location) === options.skip)
+    return false;
+
+    if (
+      options.location &&
+        path.basename(location._path, '.js') !== options.location &&
+        geography.getName(location) !== options.location
+    )
+      return false;
+
+    if (options.country && ![options.country, `iso1:${options.country}`].includes(location.country))
+      return false;
+
+    // select location based on country level id
+    // for example "yarn start -i id3:AU-VIC"
+    if (options.id && options.id !== countryLevels.getIdFromLocation(location))
+      return false;
+
+    return true;
+}
+
 
 export default async args => {
   log(`⏳ Fetching scrapers...`);
@@ -13,10 +40,21 @@ export default async args => {
   filePaths = filePaths.filter(file => file.match(/scrapers(?![^/])(?!.*\/_).*\.js$/gi));
 
   // eslint-disable-next-line
-  const sources = await Promise.all(filePaths.map(filePath => require(filePath))).then(modules => [
-    ...modules.map((module, index) => ({ _path: filePaths[index], ...module.default }))
-  ]);
-  log(`✅ Fetched ${sources.length} scrapers!`);
+  const sources = await Promise.all(
+    filePaths.map(filePath => require(filePath)))
+        .then(modules => [
+          ...modules.map((module, index) => ({ _path: filePaths[index], ...module.default }))]);
+  const filteredSources = sources.filter(m => includeLocation(m, args.options));
 
-  return { ...args, sources };
+  if (filteredSources.length === 0) {
+    log(`location filter returned 0 scrapers.  Please check docs/getting_started.`);
+  } else if (filteredSources.length < sources.length) {
+    log(`✅ Fetched ${sources.length} scrapers, filtered to ${filteredSources.length}.`);
+  } else {
+    log(`✅ Fetched ${sources.length} scrapers.`);
+  }
+  
+
+
+  return { ...args, sources: filteredSources };
 };

--- a/src/events/crawler/get-sources/validate-sources.js
+++ b/src/events/crawler/get-sources/validate-sources.js
@@ -20,10 +20,8 @@ const validateSources = async args => {
 
   if (errors.length) {
     log.error(`❌ Found ${errors.length} invalid scrapers`);
-  } else {
-    if (sources.length !== 0) {
-      log(`✅ All scrapers are valid!`);
-    }
+  } else if (sources.length !== 0) {
+    log(`✅ All scrapers are valid!`);
   }
 
   report.sources = {

--- a/src/events/crawler/get-sources/validate-sources.js
+++ b/src/events/crawler/get-sources/validate-sources.js
@@ -21,7 +21,9 @@ const validateSources = async args => {
   if (errors.length) {
     log.error(`❌ Found ${errors.length} invalid scrapers`);
   } else {
-    log(`✅ All scrapers are valid!`);
+    if (sources.length !== 0) {
+      log(`✅ All scrapers are valid!`);
+    }
   }
 
   report.sources = {

--- a/src/events/crawler/scrape-data/run-scraper.js
+++ b/src/events/crawler/scrape-data/run-scraper.js
@@ -116,33 +116,11 @@ export async function runScraper(location) {
 }
 
 const runScrapers = async args => {
-  const { sources, options } = args;
+  const { sources } = args;
 
   const locations = [];
   const errors = [];
   for (const location of sources) {
-    if (options.skip && geography.getName(location) === options.skip) {
-      continue;
-    }
-
-    if (
-      options.location &&
-      path.basename(location._path, '.js') !== options.location &&
-      geography.getName(location) !== options.location
-    ) {
-      continue;
-    }
-
-    if (options.country && ![options.country, `iso1:${options.country}`].includes(location.country)) {
-      continue;
-    }
-
-    if (options.id && options.id !== countryLevels.getIdFromLocation(location)) {
-      // select location based on country level id
-      // for example "yarn start -i id3:AU-VIC"
-      continue;
-    }
-
     if (location.scraper) {
       try {
         addData(locations, location, await runScraper(location));

--- a/src/events/crawler/scrape-data/run-scraper.js
+++ b/src/events/crawler/scrape-data/run-scraper.js
@@ -1,7 +1,5 @@
-import path from 'path';
 import datetime from '../../../shared/lib/datetime/index.js';
 import reporter from '../../../shared/lib/error-reporter.js';
-import * as countryLevels from '../../../shared/lib/geography/country-levels.js';
 import * as geography from '../../../shared/lib/geography/index.js';
 import log from '../../../shared/lib/log.js';
 

--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -16,11 +16,6 @@ const { argv } = yargs
     description: 'Scrape only the location provided by src/shared/scraper path name',
     type: 'string'
   })
-  .option('id', {
-    alias: 'i',
-    description: 'Scrape only the location provided by id',
-    type: 'string'
-  })
   .option('skip', {
     alias: 's',
     description: 'Skip the location provided by src/shared/scraper path name',

--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -13,12 +13,7 @@ const { argv } = yargs
   })
   .option('location', {
     alias: 'l',
-    description: 'Scrape only the location provided by full name, i.e City, County, State, Country',
-    type: 'string'
-  })
-  .option('country', {
-    alias: 'c',
-    description: 'Scrape only the country provided, like AUS',
+    description: 'Scrape only the location provided by src/shared/scraper path name',
     type: 'string'
   })
   .option('id', {
@@ -28,7 +23,7 @@ const { argv } = yargs
   })
   .option('skip', {
     alias: 's',
-    description: 'Skip the location provided by full name, i.e City, County, State, Country',
+    description: 'Skip the location provided by src/shared/scraper path name',
     type: 'string'
   })
   .option('outputSuffix', {

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -24,9 +24,14 @@ async function generate(date, options = {}) {
     date: date || datetime.getYYYYMD()
   };
 
+  const srcs = await fetchSources({ date, report, options });
+  if (srcs.sources.length === 0) {
+    console.log('No sources, quitting.');
+    return;
+  }
+
   // Crawler
-  const output = await fetchSources({ date, report, options })
-    .then(scrapeData)
+  const output = scrapeData(srcs)
     // processor
     .then(rateSources)
     .then(dedupeLocations)

--- a/src/shared/timeseries/run-crawler.js
+++ b/src/shared/timeseries/run-crawler.js
@@ -30,9 +30,6 @@ export default options =>
     if (options.location) {
       args = args.concat(['-l', options.location]);
     }
-    if (options.country) {
-      args = args.concat(['-c', options.country]);
-    }
 
     const child = childProcess.fork(
       path.join('src', 'shared', 'timeseries', 'worker.js'),


### PR DESCRIPTION
## Summary

Updates the `--skip` and `--location` filters to instead use relative file paths only.  We're moving to iso codes, so the filters are changing, and it's hard to guess what the right thing is.

Addresses issue #706 (yarn flags), and docs.

## Sample calls

```

$ yarn start --location "US/NV"
yarn run v1.22.4
$ node src/shared/cli/index.js --location US/NV
⏳ Fetching scrapers...
✅ Fetched 138 scrapers, filtered to 3.
... etc


$ yarn start --location "US/NV/carson-city.js"
yarn run v1.22.4
$ node src/shared/cli/index.js --location US/NV/carson-city.js
⏳ Fetching scrapers...
✅ Fetched 138 scrapers, filtered to 1.
... etc
```

`start` quits if nothing matches:

```
$ yarn start --location "xxx"
yarn run v1.22.4
$ node src/shared/cli/index.js --location xxx
⏳ Fetching scrapers...
location filter returned 0 scrapers.  Please check docs/getting_started.
No sources, quitting.
```

I didn't bother using regexes, because it seemed that there were too many chances to run the wrong thing ... e.g., "US" matches "RUS". A scraper named 'carson-city.js' exists, but this won't run it:

```
$ yarn start --location "carson"
yarn run v1.22.4
$ node src/shared/cli/index.js --location carson
⏳ Fetching scrapers...
location filter returned 0 scrapers.  Please check docs/getting_started.
No sources, quitting.
```

## Changes

* Moved scraper filtering code up to the loading of the filters.
* Quick exit during generation if there are no sources.
* Updated docs with examples.
