### PR TITLE
Fix issue 483: rus scraper breaks caching

### DIFF
--- a/src/shared/lib/fetch/get.js
+++ b/src/shared/lib/fetch/get.js
@@ -33,6 +33,9 @@ needle.defaults({
  *  - encoding: encoding to use when retrieving files from cache, defaults to utf8
  *  - method: 'get' or 'post'
  *  - args: key/value pairs to send with a POST
+ *
+ * Returns: { body: body, cookies: cookies }.  If the request failed,
+ * both body and cookies are null.
  */
 export const get = async (url, type, date = datetime.old.scrapeDate() || datetime.old.getYYYYMD(), options = {}) => {
   const { alwaysRun, disableSSL, toString, encoding, cookies, headers, method, args } = {
@@ -48,7 +51,7 @@ export const get = async (url, type, date = datetime.old.scrapeDate() || datetim
   };
 
   const cachedBody = await caching.getCachedFile(url, type, date, encoding);
-  if (process.env.ONLY_USE_CACHE) return cachedBody;
+  if (process.env.ONLY_USE_CACHE) return { body: cachedBody, cookies: null };
 
   if (cachedBody === caching.CACHE_MISS || alwaysRun) {
     log('  🚦  Loading data for %s from server', url);
@@ -103,17 +106,17 @@ export const get = async (url, type, date = datetime.old.scrapeDate() || datetim
       if (response.statusCode < 400) {
         const fetchedBody = toString ? response.body.toString() : response.body;
         await caching.saveFileToCache(url, type, date, fetchedBody);
-        return fetchedBody;
+        return { body: fetchedBody, cookies: response.cookies };
       }
 
       // 400-499 means "not found" and a retry probably won't help -- return null
       log.error(`  ❌ Got error ${response.statusCode} trying to fetch ${url}`);
-      return null;
+      return { body: null, cookies: null };
     }
 
     log.error(`  ❌ Failed to fetch ${url} after ${tries} tries`);
-    return null;
+    return { body: null, cookies: null };
   }
 
-  return cachedBody;
+  return { body: cachedBody, cookies: null };
 };

--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -28,12 +28,12 @@ const READ_TIMEOUT = 30000;
  *  - disableSSL: disables SSL verification for this resource, should be avoided
  */
 export const page = async (url, date, options = {}) => {
-  const body = await get(url, 'html', date, options);
+  const resp = await get(url, 'html', date, options);
 
-  if (!body) {
+  if (!resp.body) {
     return null;
   }
-  return cheerio.load(body);
+  return cheerio.load(resp.body);
 };
 
 /**
@@ -46,12 +46,12 @@ export const page = async (url, date, options = {}) => {
  */
 export const json = async (url, date, options = {}) => {
   log(url);
-  const body = await get(url, 'json', date, options);
+  const resp = await get(url, 'json', date, options);
 
-  if (!body) {
+  if (!resp.body) {
     return null;
   }
-  return JSON.parse(body);
+  return JSON.parse(resp.body);
 };
 
 /**
@@ -65,13 +65,13 @@ export const json = async (url, date, options = {}) => {
  */
 export const csv = async (url, date, options = {}) => {
   return new Promise(async (resolve, reject) => {
-    const body = await get(url, 'csv', date, options);
+    const resp = await get(url, 'csv', date, options);
 
-    if (!body) {
+    if (!resp.body) {
       resolve(null);
     } else {
       csvParse(
-        body,
+        resp.body,
         {
           delimiter: options.delimiter,
           columns: true
@@ -110,8 +110,8 @@ export const tsv = async (url, date, options = {}) => {
  *  - disableSSL: disables SSL verification for this resource, should be avoided
  */
 export const raw = async (url, date, options = {}) => {
-  const body = await get(url, 'raw', date, options);
-  return body;
+  const resp = await get(url, 'raw', date, options);
+  return resp.body;
 };
 
 /**
@@ -124,13 +124,13 @@ export const raw = async (url, date, options = {}) => {
  *  - disableSSL: disables SSL verification for this resource, should be avoided
  */
 export const pdf = async (url, date, options) => {
-  const body = await get(url, 'pdf', date, { ...options, toString: false, encoding: null });
+  const resp = await get(url, 'pdf', date, { ...options, toString: false, encoding: null });
 
-  if (!body) {
+  if (!resp.body) {
     return null;
   }
 
-  const data = await pdfParser(body);
+  const data = await pdfParser(resp.body);
 
   return data;
 };

--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -55,6 +55,27 @@ export const json = async (url, date, options = {}) => {
 };
 
 /**
+ * Load and parse JSON from the given URL, and return cookies as well.
+ * @param {*} url URL of the resource
+ * @param {*} date the date associated with this resource, or false if a timeseries data
+ * @param {*} options customizable options:
+ *  - alwaysRun: fetches from URL even if resource is in cache, defaults to false
+ *  - disableSSL: disables SSL verification for this resource, should be avoided
+ */
+export const jsonAndCookies = async (url, date, options = {}) => {
+  log(url);
+  const resp = await get(url, 'json', date, options);
+
+  if (!resp.body) {
+    return null;
+  }
+  return {
+    body: JSON.parse(resp.body),
+    cookies: resp.cookies
+  };
+};
+
+/**
  * Load and parse CSV from the given URL
  * @param {*} url URL of the resource
  * @param {*} date the date associated with this resource, or false if a timeseries data

--- a/src/shared/scrapers/RU/index.js
+++ b/src/shared/scrapers/RU/index.js
@@ -1,4 +1,3 @@
-import needle from 'needle';
 import { DeprecatedError } from '../../lib/errors.js';
 import * as fetch from '../../lib/fetch/index.js';
 
@@ -38,7 +37,7 @@ const scraper = {
       throw new DeprecatedError('RUS scraper did not exist for this date');
     },
     '2020-03-26': async function() {
-      const csrfRequestResponse = await needle('get', this.url, {}, { parse_response: true });
+      const csrfRequestResponse = await fetch.jsonAndCookies(this.url);
       const csrfCookies = csrfRequestResponse.cookies;
       const { csrfToken } = csrfRequestResponse.body;
 


### PR DESCRIPTION
## Summary

Fixes issue #483 , "RUS scraper breaks caching".

### Prior to this change ...

RUS would use needle directly to get a CSRF token, bypassing caching.  Here are logs for two runs, you won't see any cache hits:

On master, run 1:

```
https://yandex.ru/maps/api/covid?csrfToken=140572faa6dabfb4e04ff2875d59f177ffe5381d:1586392377
  🐢  Cache miss for https://yandex.ru/maps/api/covid?csrfToken=140572faa6dabfb4e04ff2875d59f177ffe5381d:1586392377 at coronadatascraper-cache/2020-4-8/eaf37e9f477e1e71cd489f7860445725.json
  🚦  Loading data for https://yandex.ru/maps/api/covid?csrfToken=140572faa6dabfb4e04ff2875d59f177ffe5381d:1586392377 from server
✏️  coronadatascraper-cache/2020-4-8/eaf37e9f477e1e71cd489f7860445725.json written
```

On master, run 2

```
https://yandex.ru/maps/api/covid?csrfToken=632672b8fee965318ae931435fcaa1f118d1cde0:1586392409
  🐢  Cache miss for https://yandex.ru/maps/api/covid?csrfToken=632672b8fee965318ae931435fcaa1f118d1cde0:1586392409 at coronadatascraper-cache/2020-4-8/420b8ab7a3335df48ebe5102f8cc6f82.json
  🚦  Loading data for https://yandex.ru/maps/api/covid?csrfToken=632672b8fee965318ae931435fcaa1f118d1cde0:1586392409 from server
✏️  coronadatascraper-cache/2020-4-8/420b8ab7a3335df48ebe5102f8cc6f82.json written
```

### After this change ...

The call to get the CSRF token is cached, resulting in the 2nd cached file actually being found.

With this fix, run 1:

```
https://yandex.ru/maps/api/covid?csrfToken=
  🐢  Cache miss for https://yandex.ru/maps/api/covid?csrfToken= at coronadatascraper-cache/2020-4-8/89f568b588147682c6bab1f349e5e6f4.json
  🚦  Loading data for https://yandex.ru/maps/api/covid?csrfToken= from server
✏️  coronadatascraper-cache/2020-4-8/89f568b588147682c6bab1f349e5e6f4.json written
https://yandex.ru/maps/api/covid?csrfToken=e2f99c82a8980d3a529f4b7982cfc2263c616991:1586392476
  🐢  Cache miss for https://yandex.ru/maps/api/covid?csrfToken=e2f99c82a8980d3a529f4b7982cfc2263c616991:1586392476 at coronadatascraper-cache/2020-4-8/98a631e45b11409a5b4c92729c408dde.json
  🚦  Loading data for https://yandex.ru/maps/api/covid?csrfToken=e2f99c82a8980d3a529f4b7982cfc2263c616991:1586392476 from server
✏️  coronadatascraper-cache/2020-4-8/98a631e45b11409a5b4c92729c408dde.json written
```

With this fix, run 2 (note two cache hits, one for the CSRF token, one for the next file).

```
https://yandex.ru/maps/api/covid?csrfToken=
  ⚡️ Cache hit for https://yandex.ru/maps/api/covid?csrfToken= from coronadatascraper-cache/2020-4-8/89f568b588147682c6bab1f349e5e6f4.json
https://yandex.ru/maps/api/covid?csrfToken=e2f99c82a8980d3a529f4b7982cfc2263c616991:1586392476
  ⚡️ Cache hit for https://yandex.ru/maps/api/covid?csrfToken=e2f99c82a8980d3a529f4b7982cfc2263c616991:1586392476 from coronadatascraper-cache/2020-4-8/98a631e45b11409a5b4c92729c408dde.json
```

## Changes

- changed `get.js` to return `{ body: ..., cookies: ... }`
- updated methods in `fetch.js` to check `result.body`
- added new method, `fetch.jsonAndCookies()`  (Note: I don't really like this name, but it was expedient for this fix, which we need immediately for integration test stability)
- updated RUS scraper to use `fetch.*` methods, as opposed to direct `needle` calls


## Additional notes

* I ran a full `yarn start`, and everything seemed to be in order.

## Subsequent work

* we should remove all of the old RU scraped files from the cache, they're never used.  We can tell which of the cached files are from this scraper (most of them) by doing a regex search for Russian characters.  There are about 130 files in the cache that we can remove, in a subsequent PR. .... **optionally**, in the linked issue #483 Larry had said "Finally, we will have to rename all of the historical cache files so they can be found." -- we could come up with a way to do that, creating fake "CSRF request" files which contain a set token, and then determine the file name we'd have to use for all other response files.  That would also be fine, and would save the cache.