### PR TITLE
Add 'yarn options' to list cli options.

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -126,6 +126,18 @@ This can be combined with `-l` to test a single scraper:
 yarn timeseries -d 2020-3-15 -e 2020-3-18 -l 'WA, USA'
 ```
 
+### Command-line options
+
+Run `yarn options` to see the command line options.  e.g.,
+
+```
+Options:
+  --version           Show version number                              [boolean]
+  --date, -d          Generate data for or start the timeseries at the provided
+                      date in YYYY-M-D format                           [string]
+...
+```
+
 ## Tests
 
 We use [Tape](https://github.com/substack/tape).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "deploySite": "cd dist && zip -r timeseries-tidy.csv.zip timeseries-tidy.csv && rm timeseries-tidy.csv && cd .. && yarn publishSite",
     "publishSite": "npm run buildSite && gh-pages -a -d dist/ -e .",
     "lint": "eslint .",
+    "options": "node -r esm src/shared/cli/cli-args.js -h",
     "start": "node src/shared/cli/index.js",
     "qa": "pta ./src/qa/*.qa.js -r log | node src/qa/utils/qa-reporter.js",
     "test": "tape tests/**/*-test.js | tap-spec",


### PR DESCRIPTION
## Summary

`yarn options` : A nice-to-have only, b/c I always forget what the options are.

```
$ yarn options
yarn run v1.22.4
$ node -r esm src/shared/cli/cli-args.js -h
Options:
  --version           Show version number                              [boolean]
  --date, -d          Generate data for or start the timeseries at the provided
                      date in YYYY-M-D format                           [string]
  --endDate, -e       The date after which to stop generating timeseries data
                                                                        [string]
  --location, -l      Scrape only the location provided by full name, i.e City,
                      County, State, Country                            [string]
  --country, -c       Scrape only the country provided, like AUS        [string]
  --id, -i            Scrape only the location provided by id           [string]
  --skip, -s          Skip the location provided by full name, i.e City, County,
                      State, Country                                    [string]
  --outputSuffix, -o  The suffix to add to output files, i.e. passing TEST will
                      produce data-TEST.json etc                        [string]
  --quiet, -q         Suppress logs                                    [boolean]
  --findFeatures      Include feature information in output data       [boolean]
  --findPopulations   Include population information in output data    [boolean]
  --writeData         Write to dist folder                             [boolean]
  --onlyUseCache, -x  Only use cache (no http calls)                   [boolean]
  --help, -h          Show help                                        [boolean]
✨  Done in 0.71s.
```

Docs updated.