### PR TITLE
Fix issue 637: add Z to datetime.now.utc()

### DIFF
--- a/src/shared/lib/datetime/iso/now.js
+++ b/src/shared/lib/datetime/iso/now.js
@@ -7,7 +7,7 @@ import { currentZdt } from './utils.js';
 export const now = {
   /** @returns {string} The current date and time (UTC) in ISO format. Example: `2020-03-16T23:45` */
   utc: () => {
-    return now.at('UTC');
+    return `${now.at('UTC')}Z`;
   },
 
   /**

--- a/tests/unit/shared/lib/datetime-test.js
+++ b/tests/unit/shared/lib/datetime-test.js
@@ -113,7 +113,7 @@ test('today.at', t => {
 
 test('now.utc', t => {
   mockDate('2020-03-16T23:45Z');
-  t.equal(now.utc(), '2020-03-16T23:45', 'returns the time in UTC');
+  t.equal(now.utc(), '2020-03-16T23:45Z', 'returns the time in UTC');
   mockDate.reset();
   t.end();
 });


### PR DESCRIPTION
## Summary

Fix for #637 

Before the change, datetime.now.utc() didn't have Z.
After the change, it does.

## Additional notes

@hyperknot - is this all there is to it?  I ran `yarn start` and didn't see any obvious explosions.