### PR TITLE
fix AUS scrapers (QLD, AUS from WA health)

### DIFF
--- a/src/shared/scrapers/AU/QLD/index.js
+++ b/src/shared/scrapers/AU/QLD/index.js
@@ -56,9 +56,8 @@ const scraper = {
     '2020-04-09': async function() {
       const $ = await getCurrentArticlePage(this.url);
       const $table = $('#content table');
-      console.log({ $table });
 
-      const $headings = $table.find('tbody:first-child tr th');
+      const $headings = $table.find('tbody:first-child tr th, thead:first-child tr th');
       const $totals = $table.find('tbody:last-child tr th');
       assert.equal($headings.length, $headings.length, 'headings and totals are misaligned');
 

--- a/src/shared/scrapers/AU/_shared/are-numbers-close.js
+++ b/src/shared/scrapers/AU/_shared/are-numbers-close.js
@@ -1,0 +1,8 @@
+/**
+ * Sometimes the AUS government doesn't sum numbers properly, so give them 10% slack.
+ * @param {number} computed
+ * @param {number} scraped
+ */
+const areNumbersClose = (computed, scraped) => computed * 0.9 < scraped && computed * 1.1 > scraped;
+
+export default areNumbersClose;

--- a/src/shared/scrapers/AU/aus-from-wa-health/index.js
+++ b/src/shared/scrapers/AU/aus-from-wa-health/index.js
@@ -4,6 +4,7 @@ import * as parse from '../../../lib/parse.js';
 import * as transform from '../../../lib/transform.js';
 
 import maintainers from '../../../lib/maintainers.js';
+import areNumbersClose from '../_shared/are-numbers-close.js';
 
 // WA Health has Death counts for the whole country by state,
 // even though the federal government doesn't in an accessible format.
@@ -68,7 +69,10 @@ const scraper = {
     const casesFromTotalRow = parse.number(totalRow);
 
     assert(casesFromTotalRow > 0, `Total row is not reasonable ${casesFromTotalRow}`);
-    assert.equal(summedData.cases, casesFromTotalRow, 'Summed total is not equal to number in total row');
+    assert(
+      areNumbersClose(summedData.cases, casesFromTotalRow),
+      'Summed total is not anywhere close to number in total row'
+    );
     return states;
   }
 };

--- a/src/shared/scrapers/AU/index.js
+++ b/src/shared/scrapers/AU/index.js
@@ -3,13 +3,7 @@ import * as fetch from '../../lib/fetch/index.js';
 import * as parse from '../../lib/parse.js';
 import * as transform from '../../lib/transform.js';
 import maintainers from '../../lib/maintainers.js';
-
-/**
- * Sometimes the AUS government doesn't sum numbers properly, so give them 10% slack.
- * @param {number} computed
- * @param {number} scraped
- */
-const areNumbersInTheBallpark = (computed, scraped) => computed * 0.9 < scraped && computed * 1.1 > scraped;
+import areNumbersClose from './_shared/are-numbers-close.js';
 
 const countryLevelMap = {
   'Australian Capital Territory': 'iso2:AU-ACT',
@@ -62,7 +56,7 @@ const scraper = {
 
     assert(casesFromTotalRow > 0, 'Total row is not reasonable');
     assert(
-      areNumbersInTheBallpark(summedData.cases, casesFromTotalRow),
+      areNumbersClose(summedData.cases, casesFromTotalRow),
       'Summed total is not anywhere close to number in total row'
     );
     return states;


### PR DESCRIPTION
QLD changed their header to be a proper thead.
WA states total doesn't add up, like the federal one sometimes doesn't.