### PR TITLE
fixed iso1:UA incorrect usage of county

### DIFF
--- a/src/shared/scrapers/UA/index.js
+++ b/src/shared/scrapers/UA/index.js
@@ -70,7 +70,7 @@ const scraper = {
       }
 
       regions.push({
-        county: clId,
+        state: clId,
         cases: parse.number(region.confirmed),
         deaths: parse.number(region.deaths),
         recovered: parse.number(region.recovered)


### PR DESCRIPTION
## Summary
Modified Ukraine to use `state`  rather than `county` level. This was a copy-paste mistake that wasn't caught.
<!-- What is this change about?  If it's related to an issue, please include the issue number (e.g., #426) -->

<!-- Short description, before this change ... -->

<!-- Short description, after this change ... -->

## Changes
Changed `county: clIdMap` to `state: clIdMap`
<!-- Short summary of the code.  List major points, and refer to the lines in the diff as needed. -->
