### PR TITLE
Convert Polygons to MultiPolygons for concatenating counties

### DIFF
--- a/src/events/crawler/scrape-data/run-scraper.js
+++ b/src/events/crawler/scrape-data/run-scraper.js
@@ -120,7 +120,9 @@ const runScrapers = async args => {
   for (const location of sources) {
     if (location.scraper) {
       try {
+        log(`\n\n\nBegin scraper for ${geography.getName(location)}`);
         addData(locations, location, await runScraper(location));
+        log(`Finished scraper for ${geography.getName(location)}\n\n\n`);
       } catch (err) {
         log.error('  ❌ Error processing %s: ', geography.getName(location), err);
 

--- a/src/events/processor/find-features/index.js
+++ b/src/events/processor/find-features/index.js
@@ -217,7 +217,7 @@ const generateFeatures = ({ locations, report, options, sourceRatings }) => {
       const clId = countryLevels.getIdFromLocation(location);
       if (clId) {
         const feature = await countryLevels.getFeature(clId);
-        storeFeature(feature, location);
+        if (feature !== null) storeFeature(feature, location);
         continue;
       }
 

--- a/src/events/processor/find-features/index.js
+++ b/src/events/processor/find-features/index.js
@@ -217,7 +217,7 @@ const generateFeatures = ({ locations, report, options, sourceRatings }) => {
       const clId = countryLevels.getIdFromLocation(location);
       if (clId) {
         const feature = await countryLevels.getFeature(clId);
-        if (feature !== null) storeFeature(feature, location);
+        storeFeature(feature, location);
         continue;
       }
 

--- a/src/shared/lib/geography/country-levels.js
+++ b/src/shared/lib/geography/country-levels.js
@@ -125,19 +125,14 @@ export const combineFeatureGeometry = features => {
   const newGeometry = { type: 'MultiPolygon', coordinates: [] };
 
   for (const feature of features) {
-    if (feature.geometry.type === 'Polygon') {
+    const geomType = feature.geometry.type;
+    if (geomType === 'Polygon') {
       // Wrap the coords in an array so that it looks like a MultiPolygon.
       newGeometry.coordinates = newGeometry.coordinates.concat([feature.geometry.coordinates]);
-    } else if (feature.geometry.type === 'MultiPolygon') {
+    } else if (geomType === 'MultiPolygon') {
       newGeometry.coordinates = newGeometry.coordinates.concat(feature.geometry.coordinates);
     } else {
-      const theName = feature.properties.name;
-      const theId = feature.properties.countrylevel_id;
-      const theType = feature.geometry.type;
-      assert(
-        !(theType === 'Polygon' || theType === 'MultiPolygon'),
-        `Feature geometry for ${theName} (${theId}) is ${theType}, it will not be included.`
-      );
+      throw new Error(`Invalid geometry type ${feature.properties.countrylevel_id} ${geomType}`);
     }
   }
   return newGeometry;

--- a/src/shared/lib/geography/country-levels.js
+++ b/src/shared/lib/geography/country-levels.js
@@ -74,10 +74,6 @@ export const getFeature = async id => {
       },
       geometry: newGeometry
     };
-    if (newGeometry.coordinates.length === 0) {
-      console.error(`Combined geometry for ${newFeature.properties.name} (${id}) does not contain any coordinates!`);
-      return null;
-    }
     return newFeature;
   }
   if (locationData.geojson_path) {
@@ -90,7 +86,6 @@ export const getFeature = async id => {
     feature.properties = cleanProps;
     return feature;
   }
-  return null;
 };
 
 export const getPopulation = async id => {

--- a/src/shared/lib/geography/country-levels.js
+++ b/src/shared/lib/geography/country-levels.js
@@ -4,7 +4,6 @@ import assert from 'assert';
 import path from 'path';
 import { readJSON } from '../fs.js';
 import * as geography from './index.js';
-import log from '../log.js';
 
 const LEVELS = ['iso1', 'iso2', 'fips'];
 
@@ -131,17 +130,19 @@ export const combineFeatureGeometry = features => {
   const newGeometry = { type: 'MultiPolygon', coordinates: [] };
 
   for (const feature of features) {
-    const theName = feature.properties.name;
-    const theId = feature.properties.countrylevel_id;
-    const theType = feature.geometry.type;
     if (feature.geometry.type === 'Polygon') {
-      log.warn(`Feature geometry for ${theName} (${theId}) is ${theType}, wrapping in array.`);
       // Wrap the coords in an array so that it looks like a MultiPolygon.
       newGeometry.coordinates = newGeometry.coordinates.concat([feature.geometry.coordinates]);
     } else if (feature.geometry.type === 'MultiPolygon') {
       newGeometry.coordinates = newGeometry.coordinates.concat(feature.geometry.coordinates);
     } else {
-      log.error(`Feature geometry for ${theName} (${theId}) is ${theType}, it will not be included.`);
+      const theName = feature.properties.name;
+      const theId = feature.properties.countrylevel_id;
+      const theType = feature.geometry.type;
+      assert(
+        !(theType === 'Polygon' || theType === 'MultiPolygon'),
+        `Feature geometry for ${theName} (${theId}) is ${theType}, it will not be included.`
+      );
     }
   }
   return newGeometry;

--- a/src/shared/lib/geography/country-levels.js
+++ b/src/shared/lib/geography/country-levels.js
@@ -76,16 +76,17 @@ export const getFeature = async id => {
     };
     return newFeature;
   }
-  if (locationData.geojson_path) {
-    const geojsonPath = path.join(countryLevelsDir, 'geojson', locationData.geojson_path);
-    const feature = await readJSON(geojsonPath);
-    const cleanProps = {
-      name: feature.properties.name,
-      countrylevel_id: feature.properties.countrylevel_id
-    };
-    feature.properties = cleanProps;
-    return feature;
-  }
+
+  assert(locationData.geojson_path, `Missing geojson_path for ${id}`);
+
+  const geojsonPath = path.join(countryLevelsDir, 'geojson', locationData.geojson_path);
+  const feature = await readJSON(geojsonPath);
+  const cleanProps = {
+    name: feature.properties.name,
+    countrylevel_id: feature.properties.countrylevel_id
+  };
+  feature.properties = cleanProps;
+  return feature;
 };
 
 export const getPopulation = async id => {


### PR DESCRIPTION
Reproduce the problem with `yarn start -l US/UT`. It will crash.

Some counties in usa-counties.js are of type `Polygon`; simply wrapping their coordinates in an array makes them into `MultiPolygons`, and then this concatenation will work.