### PR TITLE
DRAFT: Look for ArcGIS response and retry when fetching CSVs

### DIFF
--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -112,6 +112,13 @@ export const csv = async (url, date, options = {}) => {
         break; // response is not JSON, assume it's CSV.
       }
 
+      // We retry, but only if we're not trying to get a file from a previous day.
+      if (date && datetime.dateIsBefore(date, datetime.old.getDate())) {
+        log(`  ❌ Cached file for "${url}" is not a CSV, and we can't go back in time to ${date}.`);
+        resolve(null);
+        return;
+      }
+
       log(`  ⚠️  Expected a CSV, got JSON for "${url}`);
       if (arcGISresponse.status !== 'Processing') {
         log(`  ❌ Unknown JSON response for "${url}": ${arcGISresponse}`);

--- a/tests/unit/shared/lib/fetch-csv-test.js
+++ b/tests/unit/shared/lib/fetch-csv-test.js
@@ -1,0 +1,54 @@
+const imports = require('esm')(module);
+const { join } = require('path');
+const test = require('tape');
+const fs = require('fs');
+const path = require('path');
+
+const fetch = imports(join(process.cwd(), 'src', 'shared', 'lib', 'fetch', 'index.js'));
+const caching = imports(join(process.cwd(), 'src', 'shared', 'lib', 'fetch', 'caching.js'));
+const datetime = imports(join(process.cwd(), 'src', 'shared', 'lib', 'datetime', 'iso', 'index.js')).default;
+
+test('Module exists', t => {
+  t.plan(2);
+  t.ok(fetch, 'fetch exists');
+  t.ok(caching, 'caching exists');
+});
+
+const testURL = 'https://coronadatascraper.com/data.csv';
+const pastDate = '2020-04-01';
+const nowDate = datetime.getYYYYMMDD();
+
+test('Write fake cache files', t => {
+  // NOTE: this will fail if the cache doesn't have the directories.
+  t.plan(4);
+  const simulatedResponse = {
+    processingTime: '1.21 seconds',
+    status: 'Processing',
+    generating: {}
+  };
+  const responseString = JSON.stringify(simulatedResponse);
+
+  let cacheFilename = caching.getCachedFilePath(testURL, 'csv', pastDate);
+  let cacheDir = path.dirname(cacheFilename);
+  if (!fs.existsSync(cacheDir)) fs.mkdirSync(cacheDir);
+  t.ok(fs.existsSync(cacheDir), `cache folder ${cacheDir} exists.`);
+  fs.writeFileSync(cacheFilename, responseString, 'utf8');
+  let readBack = fs.readFileSync(cacheFilename, 'utf8');
+  t.ok(readBack === responseString, `fake cache file written to ${cacheFilename}`);
+
+  cacheFilename = caching.getCachedFilePath(testURL, 'csv', nowDate);
+  cacheDir = path.dirname(cacheFilename);
+  if (!fs.existsSync(cacheDir)) fs.mkdirSync(cacheDir);
+  t.ok(fs.existsSync(cacheDir), `cache folder ${cacheDir} exists.`);
+  fs.writeFileSync(cacheFilename, responseString, 'utf8');
+  readBack = fs.readFileSync(cacheFilename, 'utf8');
+  t.ok(readBack === responseString, `fake cache file written to ${cacheFilename}.`);
+});
+
+test('Simulate cache hit of JSON arcGIS response', async t => {
+  t.plan(2);
+  const oldFile = await fetch.csv(testURL, pastDate);
+  t.ok(oldFile === null, `Successfully gave up trying to recover from an arcGIS response in the past.`);
+  const nowFile = await fetch.csv(testURL, nowDate);
+  t.ok(nowFile !== null, `Successfully recovered from an arcGIS response.`);
+});


### PR DESCRIPTION
Requesting a CSV from an ArcGIS server could give a JSON response that tells us the server "is working on it". We previously ignored this; @jzohrab saw at least one instance of this response being cached.

This fixes that by retrying up to 5 times before giving up.

Note that in my testing with Panama, I had *several* problems getting the CSV, where it seemed the backend (on their side) was restarting the process often. In theory, instead of a fixed number of retries, we could give up once a certain amount of time was exceeded. 

Moreover, when I did get the CSV, the data was sometimes stale (i.e. it would not match what their dashboard was displaying) and we have no way of detecting that.

Anything that has an ArcGIS CSV almost certainly has a REST API to access it with, and we should transition all these to that. However, that requires handling pagination, which we are not currently doing (and would be the subject of another PR). I mention that here because this PR is then just a temporary fix until we (hopefully) transition to not pulling CSVs from ArcGIS sources anymore.

Refer to [this doc](https://docs.google.com/document/d/1__rE8LbiB0pK4qqG3vIbjbgnT8SrTx86A_KI7Xakgjk/edit#) if you have questions.