### PR TITLE
Add tool compare reports

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -25,6 +25,7 @@ _Last updated: 2020-03-26_
   - [Testing sources](#testing-sources)
     - [Test coverage](#test-coverage)
     - [Manual testing](#manual-testing)
+    - [Manual regression testing](#manual-regression-testing)
 
 This guide provides information on the criterias we use to determine whether a source should be added to the project, and offer technical details
 regarding how a source can be implemented.
@@ -435,3 +436,118 @@ The path to scraper should be the relative path under
 After the crawler has finished running, look at how many counties, states, and countries were
 scraped. Also look for missing location or population information. Finally, look at the output located in the `dist` directory. `data.json` contains all the information
 the crawler could get from your source. `report.json` provides a report on crawling process. `ratings.json` provides a rating for your source.
+
+### Manual regression testing
+
+By using the `--writeTo` and `--onlyUseCache` options, and the script
+`tools/compare-report-dirs.js`, you can do some quick regression
+testing of any changes you make to scrapers or libraries.
+
+For example, before starting work on some US/NV scrapers, you can
+generate all of the reports using only cached data, and save it to an
+arbitrary folder:
+
+```
+yarn start --date 2020-04-06 --onlyUseCache --location US/NV --writeTo zz_before
+```
+
+After doing your work, you regenerate to a different folder using the
+same cached data:
+
+```
+yarn start --date 2020-04-06 --onlyUseCache --location US/NV --writeTo zz_after
+```
+
+You can then run `tools/compare-report-dirs.js`, comparing the "left"
+and "right" folders.  Each report is listed with the differences:
+
+```
+$ node tools/compare-report-dirs.js --left zz_before --right zz_after
+
+data-2020-04-06.json
+--------------------
+* [3, Storey County, Nevada, United States]/deaths value: 0 != 41
+* [5, Washoe County, Nevada, United States]/deaths value: 4 != -1
+
+report.json
+-----------
+* /scrape/numCities value: 0 != 7
+
+ratings.json
+------------
+  equal
+
+features-2020-04-06.json
+------------------------
+* /features[5]/properties/name value: Washoe County != Washoe
+
+crawler-report.csv
+------------------
+  equal
+
+data-2020-04-06.csv
+-------------------
+* Line 3, col 79: "4" != "-"
+```
+
+#### Interpreting the json diff results
+
+For the above example, `zz_after/data-2020-04-06.json` has the
+following content:
+
+```
+[
+  { "county": ... },
+  ...
+  {
+    "county": "Washoe County",
+    "state": "Nevada",
+    "country": "United States",
+    ...
+    "cases": 281,
+    "deaths": -1,
+    "recovered": 30,
+  },
+]
+```
+
+and the diff in the report was:
+
+```
+* [5, Washoe County, Nevada, United States]/deaths value: 4 != -1
+```
+
+In the JSON diff:
+
+* `[#]` indicates an array index
+
+* Sometimes, extra annotations are added to an array index to help you
+  find it in the source JSON.  `[5, Washoe County, ...]` says that the
+  fifth element has some associated text `Washoe County` in one of its
+  elements.
+
+* `/` represents a child under a parent (or the root element if the
+  root is a hash)
+
+The diff line `[5, Washoe County, ...]/deaths value: 4 != -1`
+therefore says that the fifth element under the root, which has
+`Washoe County` in it, has a child element `deaths`, which is
+different between the two files.
+
+`4 != -1` is this difference.
+
+
+Another example from a different run:
+
+`[2703, Roberts County, South Dakota]/sources[0]/url value: X != https://doh.org`
+
+The above line says:
+
+* the root array element 2703 (Roberts County, SD) ...
+
+* has a 'sources' array, of which element 0 ...
+
+* has a 'url' property which is different:
+
+* The `--left` file contains `X`, the `--right` file contains
+  `https://doh.org`

--- a/src/events/crawler/get-sources/load-sources.js
+++ b/src/events/crawler/get-sources/load-sources.js
@@ -30,7 +30,15 @@ export default async args => {
   const sources = await Promise.all(filePaths.map(filePath => require(filePath))).then(modules => [
     ...modules.map((module, index) => ({ _path: filePaths[index], ...module.default }))
   ]);
-  const filteredSources = sources.filter(m => includeLocation(m, args.options));
+
+  // Sorting sources by path for generated report file determinism.
+  const sortSources = (a, b) => {
+    if (a._path > b._path) return 1;
+    if (b._path > a._path) return -1;
+    return 0;
+  };
+
+  const filteredSources = sources.filter(m => includeLocation(m, args.options)).sort(sortSources);
 
   if (filteredSources.length === 0) {
     log(`location filter returned 0 scrapers.  Please check docs/getting_started.`);

--- a/src/events/processor/write-data/index.js
+++ b/src/events/processor/write-data/index.js
@@ -11,17 +11,22 @@ const writeData = async ({ locations, featureCollection, report, options, source
     suffix = `-${process.env.SCRAPE_DATE}`;
   }
 
-  await fs.writeFile(path.join('dist', `data${suffix}.json`), JSON.stringify(locations, null, 2));
+  const d = options.writeTo;
+  await fs.ensureDir(d);
 
-  await fs.writeCSV(path.join('dist', `data${suffix}.csv`), stringify.csvForDay(locations));
+  const { join } = path;
 
-  await fs.writeJSON(path.join('dist', `features${suffix}.json`), featureCollection, { space: 0 });
+  await fs.writeFile(join(d, `data${suffix}.json`), JSON.stringify(locations, null, 2));
 
-  await fs.writeJSON('dist/report.json', report, { space: 2 });
+  await fs.writeCSV(join(d, `data${suffix}.csv`), stringify.csvForDay(locations));
 
-  await fs.writeJSON('dist/ratings.json', sourceRatings, { space: 2 });
+  await fs.writeJSON(join(d, `features${suffix}.json`), featureCollection, { space: 0 });
 
-  await fs.writeCSV('dist/reports/crawler-report.csv', reporter.getCSV());
+  await fs.writeJSON(join(d, 'report.json'), report, { space: 2 });
+
+  await fs.writeJSON(join(d, 'ratings.json'), sourceRatings, { space: 2 });
+
+  await fs.writeCSV(join(d, 'reports', 'crawler-report.csv'), reporter.getCSV());
 
   return { locations, featureCollection, report, options };
 };

--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -43,6 +43,11 @@ const { argv } = yargs
     description: 'Write to dist folder',
     type: 'boolean'
   })
+  .options('writeTo', {
+    description: 'Folder to write to',
+    default: 'dist',
+    type: 'string'
+  })
   .option('onlyUseCache', {
     alias: 'x',
     description: 'Only use cache (no http calls)',

--- a/src/shared/lib/diffing/json-diff.js
+++ b/src/shared/lib/diffing/json-diff.js
@@ -1,0 +1,178 @@
+/** Diff two json structures, and report places where the structures
+ * differ, up to a maximum number of differences.
+ *
+ * This provides a reasonably-descriptive place where two json
+ * structures differ, using path-style separators (e.g.,
+ * key1/key2/key3) to indicate the "hash key path", and indexes
+ * (e.g. [0]) to indicate array positions for differences.
+ *
+ * For example, given the following:
+ *
+ *  lhs = [
+ *    { 'a': 'apple',
+ *      'b': 'bat',
+ *      'c': [
+ *        { 'd': 'd-1', 'e': 'e-1' },
+ *        { 'd': 'd-2', 'e': 'e-2' }
+ *      ]
+ *    }
+ *  ];
+ *
+ *  rhs = [
+ *    { 'a': 'apple',
+ *      'b': 'bat-XXXX',
+ *      'c': [
+ *        { 'd': 'd-1', 'e': 'NOT_E_1' },
+ *        { 'd': 'NOT_D_2', 'e': 'e-2' }
+ *      ]
+ *    }
+ *  ];
+ *
+ *  The differences would be:
+ *
+ *    '[0]/b value: bat != bat-XXXX',
+ *    '[0]/c[0]/e value: e-1 != NOT_E_1',
+ *    '[0]/c[1]/d value: d-2 != NOT_D_2'
+ *
+ *
+ * Since finding things by array index is annoying, you can also pass
+ * a hash of "formatters" to the method.  The key is a path pattern to
+ * match, and the value is a function(hash, match), where "match" is
+ * the result of regex.match(current path).
+ *
+ * Continuing the above example:
+ *
+ *    const formatters = {
+ *      '^[(\\d+)]$': (hsh, m) => { return `[${m[1]}, ${hsh['a']}]`; },
+ *      '^(.*?/c)[(\\d+)]$': (hsh, m) => { return `${m[1]}[${m[2]}, ${hsh['d']}]`; },
+ *    };
+ *
+ * The key '^(.*?/c)[(\\d+)]$' is converted to a regex: /^(.*?\/c)\[(\d+)]\]$/.
+ * When an error location path matches the regex, its method is called.  For this
+ * example, the results are:
+ #
+ *    '[0, apple]/b value: bat != bat-XXXX',
+ *    '[0, apple]/c[0, d-1]/e value: e-1 != NOT_E_1',
+ *    '[0, apple]/c[1, d-2]/d value: d-2 != NOT_D_2'
+ *
+ */
+
+/** Returns true if arg is a primitive. */
+function isPrimitive(arg) {
+  const type = typeof arg;
+  return arg == null || (type !== 'object' && type !== 'function');
+}
+
+/** True if arg is a hash. */
+function isDictionary(arg) {
+  if (!arg) return false;
+  if (Array.isArray(arg)) return false;
+  if (arg.constructor !== Object) return false;
+  return true;
+}
+
+/** Return the new path to show to the user, if the current path
+ * matches any of the formaters. */
+function reformatCurrPath(hsh, currPath, formatters) {
+  let newPath = currPath;
+  for (let i = 0; i < formatters.length; ++i) {
+    const [re, formattingFunction] = formatters[i];
+    const m = newPath.match(re);
+    // console.log(`newPath: "${newPath}"; re: ${re}; m: ${m}`);
+    if (m !== null) {
+      newPath = formattingFunction(hsh, m);
+      break;
+    }
+  }
+  return newPath;
+}
+
+/** Recursion through the lhs and rhs, pushing errors (differences)
+ * onto errs, up to maxErrors. */
+function _jsonDiffIter(lhs, rhs, currPath, errs, maxErrors, formatters) {
+  if (errs.length === maxErrors) return;
+
+  const newPath = reformatCurrPath(lhs, currPath, formatters);
+
+  if (isPrimitive(lhs) && isPrimitive(rhs)) {
+    if (lhs !== rhs) {
+      errs.push(`${newPath} value: ${lhs} != ${rhs}`.trim());
+    }
+  } else if (Array.isArray(lhs) && Array.isArray(rhs)) {
+    if (lhs.length !== rhs.length) {
+      errs.push(`${newPath} array length: ${lhs.length} != ${rhs.length}`.trim());
+    } else {
+      for (let i = 0; i < lhs.length; ++i) {
+        _jsonDiffIter(lhs[i], rhs[i], `${newPath}[${i}]`, errs, maxErrors, formatters);
+      }
+    }
+  } else if (isDictionary(lhs) && isDictionary(rhs)) {
+    const lhsKeys = Object.keys(lhs).sort();
+    const rhsKeys = Object.keys(rhs).sort();
+    if (lhsKeys.toString() !== rhsKeys.toString()) {
+      errs.push(`${newPath}/ keys: [${lhsKeys}] != [${rhsKeys}]`);
+    } else {
+      lhsKeys.forEach(k => {
+        _jsonDiffIter(lhs[k], rhs[k], `${newPath}/${k}`, errs, maxErrors, formatters);
+      });
+    }
+  } else {
+    errs.push(`${newPath} value: type difference (array vs hash)`);
+  }
+}
+
+/** The formatter keys are simplified strings.  Make them regexes.
+ * e.g., "^([\d+]/c)[(\d+)]$" => /^(\[\d+\]\/c)\[(\d+)\]$" */
+function convertFormatterKeysToRegexes(formatters) {
+  const ret = [];
+  Object.keys(formatters).forEach(k => {
+    const restring = k
+      .replace(/\[/g, '\\[')
+      .replace(/\]/g, '\\]')
+      .replace(/\//g, '/');
+    // console.log(`${k} => ${restring}`);
+    const re = new RegExp(restring);
+    ret.push([re, formatters[k]]);
+  });
+  return ret;
+}
+
+/** The diff function. */
+export function jsonDiff(left, right, maxErrors = 10, formatters = {}) {
+  const errs = [];
+  const useFormatters = convertFormatterKeysToRegexes(formatters);
+  _jsonDiffIter(left, right, '', errs, maxErrors, useFormatters);
+  return errs;
+}
+
+/** Finding arrays */
+
+/** Recursively find arrays in hash, add to arrays. */
+function _findArraysIter(obj, currPath, arrays) {
+  if (Array.isArray(obj)) {
+    let p = currPath.trim();
+    if (p === '') {
+      p = 'root';
+    }
+    arrays.push(p);
+    for (let i = 0; i < obj.length; ++i) {
+      _findArraysIter(obj[i], `${currPath}[n]`, arrays);
+    }
+  } else if (isDictionary(obj)) {
+    Object.keys(obj).forEach(k => {
+      _findArraysIter(obj[k], `${currPath}/${k}`, arrays);
+    });
+  }
+}
+
+export function findArrays(obj) {
+  const arrays = [];
+  _findArraysIter(obj, '', arrays);
+
+  function onlyUnique(value, index, self) {
+    return self.indexOf(value) === index;
+  }
+  const uniques = arrays.filter(onlyUnique);
+
+  return uniques;
+}

--- a/src/shared/lib/diffing/string-diff.js
+++ b/src/shared/lib/diffing/string-diff.js
@@ -1,0 +1,39 @@
+/** Diff two strings. */
+
+export default function stringDiff(lhs, rhs) {
+  if (lhs === null || rhs === null) throw new Error('Missing lhs or rhs');
+
+  const ret = { column: null, left: '', right: '' };
+  let foundDiff = false;
+
+  const minLen = lhs.length < rhs.length ? lhs.length : rhs.length;
+  for (let i = 0; i < minLen; ++i) {
+    const lc = lhs[i];
+    const rc = rhs[i];
+    if (lc !== rc) {
+      foundDiff = true;
+      ret.column = i + 1;
+      ret.left = lc;
+      ret.right = rc;
+      break;
+    }
+  }
+
+  // Likely much better way to handle this.
+  if (!foundDiff && lhs.length < rhs.length) {
+    foundDiff = true;
+    const pos = lhs.length + 1;
+    ret.column = pos;
+    ret.left = '(end-of-string)';
+    ret.right = rhs[pos - 1];
+  }
+  if (!foundDiff && rhs.length < lhs.length) {
+    foundDiff = true;
+    const pos = rhs.length + 1;
+    ret.column = pos;
+    ret.right = '(end-of-string)';
+    ret.left = lhs[pos - 1];
+  }
+
+  return ret;
+}

--- a/tests/unit/shared/lib/diffing/json-diff-test.js
+++ b/tests/unit/shared/lib/diffing/json-diff-test.js
@@ -1,0 +1,233 @@
+const imports = require('esm')(module);
+const { join } = require('path');
+const test = require('tape');
+
+const jsonDiff = imports(join(process.cwd(), 'src', 'shared', 'lib', 'diffing', 'json-diff.js'));
+
+// Globals reused for all tests
+let lhs = null;
+let rhs = null;
+
+function diffShouldBe(t, expected) {
+  t.deepEqual(jsonDiff.jsonDiff(lhs, rhs), expected);
+  t.end();
+}
+
+test('same hash is no diff', t => {
+  lhs = { a: 'hi' };
+  rhs = lhs;
+  diffShouldBe(t, []);
+});
+
+test('hash with different order', t => {
+  lhs = { a: 'apple', b: 'bats' };
+  rhs = { b: 'bats', a: 'apple' };
+  diffShouldBe(t, []);
+});
+
+test('diff hash values', t => {
+  lhs = { a: 'apple' };
+  rhs = { a: 'ant' };
+  diffShouldBe(t, ['/a value: apple != ant']);
+});
+
+test('diff hash keys at root', t => {
+  lhs = { a: 'apple' };
+  rhs = { b: 'bat' };
+  diffShouldBe(t, ['/ keys: [a] != [b]']);
+});
+
+test('diff hash keys at child object', t => {
+  lhs = { a: 'apple', b: { a: 'apple', c: 'cat' } };
+  rhs = { a: 'apple', b: { b: 'bat', c: 'cat' } };
+  diffShouldBe(t, ['/b/ keys: [a,c] != [b,c]']);
+});
+
+test('diff values child object', t => {
+  lhs = { a: 'apple', b: { a: 'ant', c: 'cat' } };
+  rhs = { a: 'apple', b: { a: 'axe', c: 'cat' } };
+  diffShouldBe(t, ['/b/a value: ant != axe']);
+});
+
+test('can compare strings', t => {
+  lhs = 'hi';
+  rhs = 'there';
+  diffShouldBe(t, ['value: hi != there']);
+});
+
+test('same strings ok', t => {
+  lhs = 'hi';
+  rhs = 'hi';
+  diffShouldBe(t, []);
+});
+
+test('arrays in same order are equivalent', t => {
+  lhs = [1, 2, 3, 4];
+  rhs = [1, 2, 3, 4];
+  diffShouldBe(t, []);
+});
+
+test('hash pointing to arrays in same order are equivalent', t => {
+  lhs = { a: [1, 2, 3, 4] };
+  rhs = { a: [1, 2, 3, 4] };
+  diffShouldBe(t, []);
+});
+
+test('hash pointing to different types are different', t => {
+  lhs = { a: [1, 2, 3, 4] };
+  rhs = { a: { '1': '2', '3': '4' } };
+  diffShouldBe(t, ['/a value: type difference (array vs hash)']);
+});
+
+test('hash pointing to different types are different #2', t => {
+  rhs = { a: { '1': '2', '3': '4' } };
+  lhs = { a: [1, 2, 3, 4] };
+  diffShouldBe(t, ['/a value: type difference (array vs hash)']);
+});
+
+test('hash pointing to diff length arrays are different', t => {
+  lhs = { a: ['a', 'b', 'c'] };
+  rhs = { a: ['a', 'b', 'c', 'd'] };
+  diffShouldBe(t, ['/a array length: 3 != 4']);
+});
+
+test('hash pointing to arrays in different order are different', t => {
+  lhs = { a: [1, 2, 3, 4] };
+  rhs = { a: [1, 3, 2, 4] };
+  diffShouldBe(t, ['/a[1] value: 2 != 3', '/a[2] value: 3 != 2']);
+});
+
+test('can limit max number of errors', t => {
+  lhs = { a: [0, 1, 2, 3] };
+  rhs = { a: [4, 5, 6, 7] };
+  const allExpected = ['/a[0] value: 0 != 4', '/a[1] value: 1 != 5', '/a[2] value: 2 != 6', '/a[3] value: 3 != 7'];
+  t.deepEqual(jsonDiff.jsonDiff(lhs, rhs), allExpected);
+
+  const first2Expected = ['/a[0] value: 0 != 4', '/a[1] value: 1 != 5'];
+  t.deepEqual(jsonDiff.jsonDiff(lhs, rhs, 2), first2Expected);
+  t.end();
+});
+
+test('documentation example', t => {
+  lhs = [
+    {
+      a: 'apple',
+      b: 'bat',
+      c: [
+        { d: 'd-1', e: 'e-1' },
+        { d: 'd-2', e: 'e-2' }
+      ]
+    }
+  ];
+  rhs = [
+    {
+      a: 'apple',
+      b: 'bat-XXXX',
+      c: [
+        { d: 'd-1', e: 'NOT_E_1' },
+        { d: 'NOT_D_2', e: 'e-2' }
+      ]
+    }
+  ];
+  const expected = [
+    '[0]/b value: bat != bat-XXXX',
+    '[0]/c[0]/e value: e-1 != NOT_E_1',
+    '[0]/c[1]/d value: d-2 != NOT_D_2'
+  ];
+  diffShouldBe(t, expected);
+});
+
+test('can use formatters to add details to path output', t => {
+  lhs = [
+    {
+      a: 'apple',
+      b: 'bat',
+      c: [
+        { d: 'd-1', e: 'e-1' },
+        { d: 'd-2', e: 'e-2' }
+      ]
+    }
+  ];
+  rhs = [
+    {
+      a: 'apple',
+      b: 'bat-XXXX',
+      c: [
+        { d: 'd-1', e: 'NOT_E_1' },
+        { d: 'NOT_D_2', e: 'e-2' }
+      ]
+    }
+  ];
+
+  const formatters = {
+    '^[(\\d+)]$': (hsh, m) => {
+      return `[${m[1]}, ${hsh.a}]`;
+    },
+    '^(.*?/c)[(\\d+)]$': (hsh, m) => {
+      return `${m[1]}[${m[2]}, ${hsh.d}]`;
+    }
+  };
+  const actual = jsonDiff.jsonDiff(lhs, rhs, 10, formatters);
+  const expected = [
+    '[0, apple]/b value: bat != bat-XXXX',
+    '[0, apple]/c[0, d-1]/e value: e-1 != NOT_E_1',
+    '[0, apple]/c[1, d-2]/d value: d-2 != NOT_D_2'
+  ];
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('array of hashes with differences', t => {
+  lhs = [
+    {
+      a: 'apple',
+      b: 'bat',
+      c: { cats: ['tiger', 'lion'] }
+    },
+    {
+      a2: 'apple2',
+      b2: 'bat2',
+      c2: { cats2: ['tiger2', 'lion2'] }
+    }
+  ];
+  rhs = [
+    {
+      a: 'apple',
+      b: 'bat',
+      c: { cats: ['tiger', 'lion'] }
+    },
+    {
+      a2: 'XXXXXapple2',
+      b2: 'XXXXXbat2',
+      c2: { cats2: ['tiger2', 'XXXXlion2'] }
+    }
+  ];
+
+  const expected = [
+    '[1]/a2 value: apple2 != XXXXXapple2',
+    '[1]/b2 value: bat2 != XXXXXbat2',
+    '[1]/c2/cats2[1] value: lion2 != XXXXlion2'
+  ];
+  diffShouldBe(t, expected);
+});
+
+// ///////////
+
+test('findArrays: initial', t => {
+  lhs = [
+    {
+      a: 'apple',
+      b: 'bat',
+      c: { cats: ['tiger', 'lion'] }
+    },
+    {
+      a: 'apple2',
+      b: 'bat2',
+      c: { cats: ['tiger2', 'lion2'] }
+    }
+  ];
+  const expected = ['root', '[n]/c/cats'];
+  const ret = jsonDiff.findArrays(lhs);
+  t.deepEqual(ret, expected);
+  t.end();
+});

--- a/tests/unit/shared/lib/diffing/string-diff-test.js
+++ b/tests/unit/shared/lib/diffing/string-diff-test.js
@@ -1,0 +1,57 @@
+const imports = require('esm')(module);
+const { join } = require('path');
+const test = require('tape');
+
+const stringDiff = imports(join(process.cwd(), 'src', 'shared', 'lib', 'diffing', 'string-diff.js')).default;
+
+let lhs = '';
+let rhs = '';
+
+function diffShouldBe(t, expected) {
+  t.deepEqual(stringDiff(lhs, rhs), expected);
+  t.end();
+}
+
+test('same string is no diff', t => {
+  const s = 'Hello there!';
+  lhs = s;
+  rhs = s;
+  diffShouldBe(t, { column: null, left: '', right: '' });
+});
+
+test('different string', t => {
+  lhs = 'Here is 1 string';
+  rhs = 'Here is 2 string';
+  diffShouldBe(t, { column: 9, left: '1', right: '2' });
+});
+
+test('different first char', t => {
+  lhs = 'Ball';
+  rhs = 'Fall';
+  diffShouldBe(t, { column: 1, left: 'B', right: 'F' });
+});
+
+test('shorter left', t => {
+  lhs = 'Here is';
+  rhs = 'Here is 2 string';
+  diffShouldBe(t, { column: 8, left: '(end-of-string)', right: ' ' });
+});
+
+test('shorter right', t => {
+  lhs = 'Here is 1 string';
+  rhs = 'Here is 1 ';
+  diffShouldBe(t, { column: 11, left: 's', right: '(end-of-string)' });
+});
+
+test('empty right', t => {
+  lhs = 'Here is 1 string';
+  rhs = '';
+  diffShouldBe(t, { column: 1, left: 'H', right: '(end-of-string)' });
+});
+
+test('either null throws', t => {
+  lhs = 'Here is 1 string';
+  rhs = null;
+  t.throws(() => stringDiff(lhs, rhs));
+  t.end();
+});

--- a/tools/compare-report-dirs.js
+++ b/tools/compare-report-dirs.js
@@ -1,0 +1,196 @@
+/** Compare two folders of Covid Data Scraper reports.
+ *
+ * Given two folders, this script diffs the corresponding reports, and
+ * prints the differences to console log.  Call this script from the
+ * command line.
+ *
+ * Usage:
+ * node ${this_file} --left <one folder> --right <other folder>
+ *
+ * Sample annotated output:
+ *
+ *    $ node tests/regression/compare.js --left zzzBase/ --right zzzOther/
+ *
+ *    data-2020-4-9.json
+ *    ------------------
+ *    * [2703, Roberts County, South Dakota]/sources[0]/url value: X != https://doh.org
+ *
+ *    Explanation:
+ *    Nested json structures are separated by `/`.  `[#]` indicates an array.
+ *    Some "formatters" are used to add extra info to the diff report.
+ *    So, the above line says:
+ *    * For the two files zzzBase/data-2020-4-9.json and zzzOther/data-2020-4-9.json,
+ *    * - root array element 2703 (Roberts County, SD) ...
+ *    * - has a 'sources' array, of which element 0 ...
+ *    * - has a 'url' property which is different:
+ *    * the `--left` file contains `X`, the `--right` file contains `https://doh.org`
+ *
+ *    reports/crawler-report.csv
+ *    --------------------------
+ *    * Line 154, col 51: "," != "s"
+ *
+ *    features-2020-4-9.json
+ *    ----------------------
+ *      equal
+ *
+ *    The corresponding files in the `--left` and `--right` directories are equal.
+ */
+
+const imports = require('esm')(module);
+const path = require('path');
+const fs = require('fs');
+
+const yargs = imports('yargs');
+const glob = require('fast-glob').sync;
+
+const lib = path.join(process.cwd(), 'src', 'shared', 'lib');
+const jsonDiff = imports(path.join(lib, 'diffing', 'json-diff.js'));
+const stringDiff = imports(path.join(lib, 'diffing', 'string-diff.js')).default;
+
+// Utilities /////////////////////////////////////////
+
+/** Compare two json files. */
+function compareJson(leftFname, rightFname, formatters) {
+  const loadJson = f => {
+    return JSON.parse(fs.readFileSync(f, 'utf8'));
+  };
+  const left = loadJson(leftFname);
+  const right = loadJson(rightFname);
+  const errs = jsonDiff.jsonDiff(left, right, 10, formatters);
+  if (errs.length === 0) console.log('  equal');
+  else
+    errs.forEach(e => {
+      console.log(`* ${e}`);
+    });
+}
+
+/** Compare two CSV files. */
+function compareCsv(leftFname, rightFname) {
+  const loadlines = f => {
+    return fs.readFileSync(f, 'utf8').match(/[^\r\n]+/g);
+  };
+  const left = loadlines(leftFname);
+  const right = loadlines(rightFname);
+
+  const errs = [];
+  if (left.length !== right.length) {
+    errs.push(`Different line count (${left.length} vs ${right.length})`);
+  }
+
+  const minLength = left.length < right.length ? left.length : right.length;
+  for (let i = 0; i < minLength; ++i) {
+    const diff = stringDiff(left[i], right[i]);
+    if (diff.column !== null) errs.push(`Line ${i}, col ${diff.column}: "${diff.left}" != "${diff.right}"`);
+    if (errs.length >= 10) break;
+  }
+
+  if (errs.length === 0) console.log('  equal');
+  else
+    errs.forEach(e => {
+      console.log(`* ${e}`);
+    });
+}
+
+/** Find _one_ file in leftPaths and rightPaths that matches the
+ * regex. */
+function findLeftRightFiles(regex, leftPaths, rightPaths) {
+  function findFile(files, regex) {
+    const drs = files.filter(f => {
+      return regex.test(f);
+    });
+    if (drs.length === 0) {
+      console.log(`Missing ${regex} file.`);
+      return null;
+    }
+    if (drs.length > 1) {
+      console.log(`Multiple/ambiguous ${regex} files.`);
+      return null;
+    }
+    return drs[0];
+  }
+  return [findFile(leftPaths, regex), findFile(rightPaths, regex)];
+}
+
+// Main method /////////////////////////////////////////
+
+/** Compare reports in "left" and "right" folders. */
+function compareReportFolders(left, right) {
+  const fpaths = d => {
+    return glob(path.join(d, '**', '*.*')).sort();
+  };
+  const leftPaths = fpaths(left);
+  const rightPaths = fpaths(right);
+
+  const printTitle = s => {
+    const b = path.basename(s);
+    console.log(`\n${b}\n${'-'.repeat(b.length)}`);
+  };
+
+  const jsonReports = [
+    {
+      regex: /data(.*).json/,
+      formatters: {
+        '^[(\\d+)]$': (h, m) => {
+          return `[${m[1]}, ${h.name}]`;
+        }
+      }
+    },
+    {
+      regex: /report.json/,
+      formatters: {
+        '^(.*?/sources)[(\\d+)]$': (h, m) => {
+          return `${m[1]}[${m[2]}, ${h.url}]`;
+        }
+      }
+    },
+    {
+      regex: /ratings.json/,
+      formatters: {
+        '^[(\\d+)]$': (h, m) => {
+          return `[${m[1]}, ${h.url}]`;
+        }
+      }
+    },
+    {
+      regex: /features(.*).json/,
+      formatters: {}
+    }
+  ];
+
+  jsonReports.forEach(hsh => {
+    const [left, right] = findLeftRightFiles(hsh.regex, leftPaths, rightPaths);
+    if (left && right) {
+      printTitle(left);
+      compareJson(left, right, hsh.formatters);
+    }
+  });
+
+  const csvReports = [/crawler-report.csv/, /data(.*).csv/];
+  csvReports.forEach(regex => {
+    const [left, right] = findLeftRightFiles(regex, leftPaths, rightPaths);
+    if (left && right) {
+      printTitle(left);
+      compareCsv(left, right);
+    }
+  });
+}
+
+// Entry point /////////////////////////////////////////
+
+const { argv } = yargs
+  .option('left', {
+    alias: 'l',
+    description: 'Left folder',
+    type: 'string',
+    default: 'dist'
+  })
+  .option('right', {
+    alias: 'r',
+    description: 'Right folder',
+    type: 'string'
+  })
+  .demand(['left', 'right'], 'Please specify both directories')
+  .version(false)
+  .help();
+
+compareReportFolders(argv.left, argv.right);


### PR DESCRIPTION
## Summary

This adds a simple diffing script for generated CSV and JSON reports,
with human-friendly output.  This lets devs refactor and verify code
more safely.

The script usage is detailed in the docs.  In summary, here's how it's used:

Before starting work (or git checkout a SHA you want to use as
reference), generate baseline reports:

```
yarn start --date 2020-04-06 --onlyUseCache --location US/NV --writeTo zz_before
```

After doing your work, regenerate to a different folder using the same
cached data:

```
yarn start --date 2020-04-06 --onlyUseCache --location US/NV --writeTo zz_after
```

Use new script `tools/compare-report-dirs.js`, comparing the "left"
and "right" folders.  Each report is listed with the differences:

```
$ node tools/compare-report-dirs.js --left zz_before --right zz_after

data-2020-04-06.json
--------------------
- [3, Storey County, Nevada, United States]/deaths value: 0 != 41
- [5, Washoe County, Nevada, United States]/deaths value: 4 != -1
...
```

The interpretation of the diff is covered in the docs.


## Changes

- Added `--writeTo` command line option
- Sources are sorted, to simplify comparison
- New libs and tests

## Additional notes

I haven't done this yet, but this code could likely be used in some
form for automated regression testing and reporting.  I haven't done
that yet as it implies that we have some regression baseline data
committed, and I wasn't sure if we could do that without introducing
too many failing CI test runs.  This is still potentially a useful
tool for devs and QA.
