### PR TITLE
add additional assertion to ID, their site seems flaky

### DIFF
--- a/src/shared/scrapers/IN/index.js
+++ b/src/shared/scrapers/IN/index.js
@@ -67,17 +67,17 @@ const scraper = {
   async scraper() {
     const $ = await fetch.page(this.url);
     const $table = $('#state-data');
-    const $trs = $table.find('tbody > tr');
-    const states = [];
+    assert.equal($table.length, 'The table can not be found');
 
     const $headings = $table.find('thead tr th');
     const dataKeysByColumnIndex = [];
-
     $headings.each((index, heading) => {
       const $heading = $(heading);
       dataKeysByColumnIndex[index] = getKey({ label: $heading.text(), labelFragmentsByKey });
     });
 
+    const states = [];
+    const $trs = $table.find('tbody > tr');
     $trs
       .filter(
         // Remove summary rows


### PR DESCRIPTION
## Summary
This scraper sometimes fails, I think they can't handle the traffic volume. Lets add an assertion early on in the pipe so we know if its the scraping logic or just the whole page that is (generally temporarily) broken.