### PR TITLE
add additional assertion to ID, their site seems flaky

### DIFF
--- a/src/shared/scrapers/ID/index.js
+++ b/src/shared/scrapers/ID/index.js
@@ -23,6 +23,8 @@ const scraper = {
     const data = {};
     const $ = await fetch.page(this.url);
     const $table = $('.covid-case-container table');
+    assert.equal($table.length, 1, 'The table can not be found, the page may not have loaded correctly');
+
     const $trs = $table.find('tbody tr');
     $trs.each((index, tr) => {
       const $tr = $(tr);

--- a/src/shared/scrapers/IN/index.js
+++ b/src/shared/scrapers/IN/index.js
@@ -67,7 +67,7 @@ const scraper = {
   async scraper() {
     const $ = await fetch.page(this.url);
     const $table = $('#state-data');
-    assert.equal($table.length, 'The table can not be found');
+    assert.equal($table.length, 1, 'The table can not be found');
 
     const $headings = $table.find('thead tr th');
     const dataKeysByColumnIndex = [];


### PR DESCRIPTION
## Summary
(I accidentally added to India instead of Indonesia before, oops! Oh well it won't hurt India to have an extra assertion anyway.)

This scraper sometimes fails, I think they can't handle the traffic volume. Lets add an assertion early on in the pipe so we know if its the scraping logic or just the whole page that is (generally temporarily) broken.