### PR TITLE
Sample API change, and tests to verify.

### DIFF
--- a/src/shared/scrapers/US/PA/index.js
+++ b/src/shared/scrapers/US/PA/index.js
@@ -90,7 +90,7 @@ const scraper = {
     '0': async function scraper() {
       this.url = 'https://www.health.pa.gov/topics/disease/Pages/Coronavirus.aspx';
       this.type = 'list';
-      const $ = await fetch.page(this.url);
+      const $ = await fetch.page(this, this.url, 'default');
       let counties = [];
       const $lis = $('li:contains("Counties impacted to date include")')
         .nextAll('ul')
@@ -116,7 +116,7 @@ const scraper = {
     '2020-03-16': async function scraper() {
       this.url = 'https://www.health.pa.gov/topics/disease/Pages/Coronavirus.aspx';
       this.type = 'table';
-      const $ = await fetch.page(this.url);
+      const $ = await fetch.page(this, this.url, 'default');
       const $table = $('table.ms-rteTable-default').first();
       const $trs = $table.find('tbody > tr');
       let counties = [];
@@ -135,7 +135,7 @@ const scraper = {
     '2020-03-17': async function scraper() {
       this.url = 'https://www.health.pa.gov/topics/disease/Pages/Coronavirus.aspx';
       this.type = 'table';
-      const $ = await fetch.page(this.url);
+      const $ = await fetch.page(this, this.url, 'default');
       const $table = $('table.ms-rteTable-default').eq(1);
       const $trs = $table.find('tbody > tr');
       let counties = [];
@@ -154,7 +154,7 @@ const scraper = {
     '2020-03-18': async function scraper() {
       this.url = 'https://www.health.pa.gov/topics/disease/coronavirus/Pages/Cases.aspx';
       this.type = 'table';
-      const $ = await fetch.page(this.url);
+      const $ = await fetch.page(this, this.url, 'default');
       const $countyTable = $('th:contains("County")').closest('table');
       const $trs = $countyTable.find('tbody > tr:not(:first-child)');
       let counties = [];

--- a/src/shared/scrapers/US/PA/index.js
+++ b/src/shared/scrapers/US/PA/index.js
@@ -179,6 +179,9 @@ const scraper = {
       this.url = 'https://www.health.pa.gov/topics/disease/coronavirus/Pages/Cases.aspx';
       this.type = 'table';
       const $ = await fetch.page(this.url);
+      const dummyCall = await fetch.page(this.url,
+        other_args_on_next_line);
+
       const $countyTable = $('td:contains("County")').closest('table');
 
       const rules = {

--- a/tests/unit/shared/scrapers/scrapers-all-test.js
+++ b/tests/unit/shared/scrapers/scrapers-all-test.js
@@ -2,7 +2,7 @@ const imports = require('esm')(module);
 const { join } = require('path');
 const test = require('tape');
 const fastGlob = require('fast-glob');
-
+const fs = require('fs');
 const shared = join(process.cwd(), 'src', 'shared');
 const lib = join(shared, 'lib');
 const schema = imports(join(lib, 'schema.js'));
@@ -29,4 +29,66 @@ test('scrapers-all-test: all scraper schema', async t => {
     t.notOk(hasErrors, `${s.name} schema ok`);
   }
   t.end();
+});
+
+
+const scraperCodeFiles = allJs
+      .map(f => {
+        const content = fs.readFileSync(f, 'utf-8');
+        const m = content.match(/fetch\..*/g);
+        return {
+          shortName: f.replace(scraperRoot, '').trim(),
+          importsFetch: /fetch.*?index.js/.test(content),
+          fetchLines: m
+        }
+      });
+
+function validateCodingConventions(t, lin) {
+  // Having the fetch all one line helps with code instrumentation
+  // (regex search-and-replace).
+  t.ok(lin.trim().endsWith(');'), `"${lin}" ends with ');'`);
+
+  // Each call should have the scraper object, the URL, and the
+  // "cache key".
+  // console.log(lin);
+  const fetchArgs = lin
+        .trim()
+        .replace(/.*\(/, '')
+        .replace(/\);$/, '')
+        .split(',')
+        .map(s => s.trim());
+  const lenMsg = `Expected >=3 args to fetch (scraper, url, cacheKey), got ${fetchArgs.length}`;
+  t.ok(fetchArgs.length >= 3, lenMsg);
+
+  if (fetchArgs.length >= 3) {
+    const first = fetchArgs[0];
+    const third = fetchArgs[2];
+
+    // First arg: Most scrapers can pass 'this', but some scrapers
+    // use helper functions, and so must pass 'obj'.
+    t.ok(first == 'this' || first == 'obj', 'first arg is this or obj');
+
+    // Third arg: Must be cache key.
+    const apos = "'";
+    const ckmsg = `third arg (${third}) is cache key, must be string`;
+    t.ok(third.startsWith(apos) && third.endsWith(apos), ckmsg);
+  }
+}
+
+const checkFiles = scraperCodeFiles.filter(scf => scf.importsFetch)
+      .filter(HACK => HACK.shortName === '/US/PA/index.js');  // HACK for demo only.
+
+checkFiles.forEach(scf => {
+  scf.fetchLines.forEach(lin => {
+    const testname = `${scf.shortName} fetch coding conventions (line "${lin}")`;
+    test(testname, async t => {
+      try {
+        validateCodingConventions(t, lin);
+      } catch (err) {
+        t.fail(err);
+      } finally {
+        t.end();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Sample proposed API call, and a set of unit tests to verify.  This will significantly simplify migrating the cache to the new layout.

All `fetch` methods will pass three args minimum: `fetch.<method>(ref_to_scraper, url, '<cache-key>' `

* `ref_to_scraper` is used so that the cache can get the scraper's file path name (via `_path`)
* `cache-key` will not be used in the current code, but will be useful for cache migration, b/c cache in v1.0 uses these to differentiate files.  In almost all cases, this string will be `'default'`.

The `fetch` method should also all be on one single line ... I know this is nitpicky, but it makes the stupid test much easier to write.

With the tests, the hack changes on US/PA pass for some lines, and fail with the following:

```
# /US/PA/index.js fetch coding conventions (line "fetch.page(this.url);")
ok 171 "fetch.page(this.url);" ends with ');'
not ok 172 Expected >=3 args to fetch (scraper, url, cacheKey), got 1

...

# /US/PA/index.js fetch coding conventions (line "fetch.page(this, this.url, 'default');")
ok 167 "fetch.page(this, this.url, 'default');" ends with ');'
ok 168 Expected >=3 args to fetch (scraper, url, cacheKey), got 3
ok 169 first arg is this or obj

...

# /US/PA/index.js fetch coding conventions (line "fetch.page(this.url,")
not ok 173 "fetch.page(this.url," ends with ');'
not ok 174 Expected >=3 args to fetch (scraper, url, cacheKey), got 2

```

I'll make all of these changes myself, and will also provide before/after runs for all cached files, verifying that the various report files don't change.