### PR TITLE
Change all scrapers fetch on single line

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start": "node src/shared/cli/index.js",
     "qa": "pta ./src/qa/*.qa.js -r log | node src/qa/utils/qa-reporter.js",
     "test": "tape tests/**/*-test.js | tap-spec",
+    "test:unit": "tape tests/unit/**/*-test.js | tap-spec",
     "test:watch": "tape-watch tests/**/*-test.js -p tap-spec",
     "test:tz": "tape scripts/test-timezones.js | tap-spec",
     "timeseries": "node src/shared/timeseries/index.js",

--- a/src/shared/scrapers/AT/index.js
+++ b/src/shared/scrapers/AT/index.js
@@ -37,7 +37,8 @@ const scraper = {
         }
       ];
 
-      const casesData = (await fetch.csv(this.url, false)).filter(item => datetime.scrapeDateIs(item.datetime));
+      const casesRaw = await fetch.csv(this.url, false);
+      const casesData = casesRaw.filter(item => datetime.scrapeDateIs(item.datetime));
 
       if (casesData.length > 0) {
         const casesByRegion = {};
@@ -71,9 +72,9 @@ const scraper = {
 
       const data = [];
 
-      const casesRegionData = JSON.parse(
-        (await fetch.fetch('https://info.gesundheitsministerium.at/data/Bundesland.js', 'txt')).body.match(/\[.*\]/g)
-      );
+      const casesUrl = 'https://info.gesundheitsministerium.at/data/Bundesland.js';
+      const casesRaw = await fetch.fetch(casesUrl, 'txt');
+      const casesRegionData = JSON.parse(casesRaw.body.match(/\[.*\]/g));
 
       const casesByRegion = {};
 

--- a/src/shared/scrapers/BR/index.js
+++ b/src/shared/scrapers/BR/index.js
@@ -60,7 +60,7 @@ const scraper = {
   async scraper() {
     const response = [];
     const ufs = this._ufs;
-    const $ = await fetch.headless(this.url); // , false
+    const $ = await fetch.headless(this.url);
 
     $.root()
       .find('.list-itens .teste')

--- a/src/shared/scrapers/CY/index.js
+++ b/src/shared/scrapers/CY/index.js
@@ -22,7 +22,8 @@ const scraper = {
   async scraper() {
     const date = datetime.getYYYYMMDD(process.env.SCRAPE_DATE);
 
-    const casesData = (await fetch.csv(this.url, false)).filter(item => datetime.scrapeDateIs(reformatDate(item.date)));
+    const casesRaw = await fetch.csv(this.url, false);
+    const casesData = casesRaw.filter(item => datetime.scrapeDateIs(reformatDate(item.date)));
 
     if (casesData.length > 0) {
       const data = {};

--- a/src/shared/scrapers/LT/index.js
+++ b/src/shared/scrapers/LT/index.js
@@ -18,7 +18,8 @@ const scraper = {
   ],
   maintainers: [maintainers.qgolsteyn],
   async scraper() {
-    const casesData = (await fetch.json(this.url, false)).features.map(({ attributes }) => attributes);
+    const casesRaw = await fetch.json(this.url, false);
+    const casesData = casesRaw.features.map(({ attributes }) => attributes);
 
     const casesByRegion = {};
 

--- a/src/shared/scrapers/LV/index.js
+++ b/src/shared/scrapers/LV/index.js
@@ -17,7 +17,8 @@ const scraper = {
     }
   ],
   async scraper() {
-    const casesData = (await fetch.json(this.url)).features.map(({ attributes }) => attributes);
+    const casesRaw = await fetch.json(this.url);
+    const casesData = casesRaw.features.map(({ attributes }) => attributes);
 
     const data = [];
 

--- a/src/shared/scrapers/NL/index.js
+++ b/src/shared/scrapers/NL/index.js
@@ -23,17 +23,14 @@ const scraper = {
   async scraper() {
     const date = datetime.getYYYYMMDD(process.env.SCRAPE_DATE);
 
-    const casesData = (
-      await fetch.csv(
-        'https://raw.githubusercontent.com/J535D165/CoronaWatchNL/master/data/rivm_NL_covid19_province.csv',
-        false
-      )
-    ).filter(item => datetime.scrapeDateIs(item.Datum));
+    const casesUrl =
+      'https://raw.githubusercontent.com/J535D165/CoronaWatchNL/master/data/rivm_NL_covid19_province.csv';
+    const casesRaw = await fetch.csv(casesUrl, false);
+    const casesData = casesRaw.filter(item => datetime.scrapeDateIs(item.Datum));
 
-    const nationalData = await fetch.csv(
-      'https://raw.githubusercontent.com/J535D165/CoronaWatchNL/master/data/rivm_NL_covid19_national.csv',
-      false
-    );
+    const nationalUrl =
+      'https://raw.githubusercontent.com/J535D165/CoronaWatchNL/master/data/rivm_NL_covid19_national.csv';
+    const nationalData = await fetch.csv(nationalUrl, false);
 
     const hospitalized = nationalData.find(
       item => datetime.scrapeDateIs(item.Datum) && item.Type === 'Ziekenhuisopname'

--- a/src/shared/scrapers/SA/index.js
+++ b/src/shared/scrapers/SA/index.js
@@ -17,7 +17,8 @@ const scraper = {
   async scraper() {
     const date = datetime.getYYYYMMDD(process.env.SCRAPE_DATE);
 
-    const dataset = (await fetch.csv(this.url, false))
+    const raw = await fetch.csv(this.url, false);
+    const dataset = raw
       .filter(item => item.region !== 'Total')
       .map(item => ({ ...item, region: mapping[item.region] }));
 

--- a/src/shared/scrapers/SE/index.js
+++ b/src/shared/scrapers/SE/index.js
@@ -16,7 +16,8 @@ const scraper = {
   async scraper() {
     const date = datetime.getYYYYMMDD(process.env.SCRAPE_DATE);
 
-    const casesData = (await fetch.json(this.url, false)).features.map(({ attributes }) => attributes);
+    const casesRaw = await fetch.json(this.url, false);
+    const casesData = casesRaw.features.map(({ attributes }) => attributes);
 
     const casesByRegion = {};
 

--- a/src/shared/scrapers/SI/index.js
+++ b/src/shared/scrapers/SI/index.js
@@ -21,10 +21,8 @@ const scraper = {
     const date = datetime.getYYYYMMDD(process.env.SCRAPE_DATE);
 
     const casesData = await fetch.csv(this.url, false);
-    const regionData = await fetch.csv(
-      'https://raw.githubusercontent.com/slo-covid-19/data/master/csv/regions.csv',
-      false
-    );
+    const regionUrl = 'https://raw.githubusercontent.com/slo-covid-19/data/master/csv/regions.csv';
+    const regionData = await fetch.csv(regionUrl, false);
 
     let nationalData = {};
 

--- a/src/shared/scrapers/US/DC/index.js
+++ b/src/shared/scrapers/US/DC/index.js
@@ -33,19 +33,14 @@ const scraper = {
         cookies: httpResponse.cookies
       };
 
-      const form = await fetch.page(
-        'https://microstrategy.dc.gov/MicroStrategy/servlet/mstrWeb?evt=3067&src=mstrWeb.3067&reportID=DA2251A711EA6FB482660080EFA55B20&reportViewMode=1',
-        false,
-        getOptions
-      );
+      const formUrl =
+        'https://microstrategy.dc.gov/MicroStrategy/servlet/mstrWeb?evt=3067&src=mstrWeb.3067&reportID=DA2251A711EA6FB482660080EFA55B20&reportViewMode=1';
+      const form = await fetch.page(formUrl, false, getOptions);
 
       const rb = form('form input[name="rb"]').val();
 
-      const data = await fetch.raw(
-        `https://microstrategy.dc.gov/MicroStrategy/export/Health_Statistics.csv?evt=3012&src=mstrWeb.3012&exportSection=1&exportFormatGrids=csvIServer&exportPlaintextDelimiter=1&exportMetricValuesAsText=0&exportHeadersAsText=0&exportFilterDetails=0&exportOverlapGridTitles=3&SaveReportProperties=*-1.*-1.0.0.0&rb=${rb}`,
-        false,
-        getOptions
-      );
+      const rawUrl = `https://microstrategy.dc.gov/MicroStrategy/export/Health_Statistics.csv?evt=3012&src=mstrWeb.3012&exportSection=1&exportFormatGrids=csvIServer&exportPlaintextDelimiter=1&exportMetricValuesAsText=0&exportHeadersAsText=0&exportFilterDetails=0&exportOverlapGridTitles=3&SaveReportProperties=*-1.*-1.0.0.0&rb=${rb}`;
+      const data = await fetch.raw(rawUrl, false, getOptions);
 
       const json = await new Promise((resolve, reject) => {
         csvParse(data.slice(data.indexOf('"')).replace(/\0|\*/g, ''), (err, output) => {

--- a/src/shared/scrapers/US/GA/index.js
+++ b/src/shared/scrapers/US/GA/index.js
@@ -210,7 +210,8 @@ const scraper = {
       return counties;
     },
     '2020-03-27': async function() {
-      const pageHTML = (await fetch.page(this.url)).html();
+      const tmp = await fetch.page(this.url);
+      const pageHTML = tmp.html();
       [this.url] = pageHTML.match(/https:\/\/(.*)\.cloudfront\.net/);
 
       const $ = await fetch.page(this.url);

--- a/src/shared/scrapers/US/KS/index.js
+++ b/src/shared/scrapers/US/KS/index.js
@@ -296,9 +296,8 @@ const scraper = {
         cases: parse.number(caseNum)
       });
 
-      const deathData = await fetch.pdf(
-        'https://public.tableau.com/views/COVID-19Data_15851817634470/Mortality.pdf?:showVizHome=no'
-      );
+      const pdfUrl = 'https://public.tableau.com/views/COVID-19Data_15851817634470/Mortality.pdf?:showVizHome=no';
+      const deathData = await fetch.pdf(pdfUrl);
       let totalDeaths = '';
       deathData.forEach(item => {
         if (item && item.text.match(/[0-9]/)) {

--- a/src/shared/scrapers/US/MD/index.js
+++ b/src/shared/scrapers/US/MD/index.js
@@ -66,11 +66,9 @@ const scraper = {
     '2020-03-25': async function() {
       // 2020-3-24 is the last day this was updated
       this.type = 'csv';
-      this.url = await fetch.getArcGISCSVURL(
-        '',
-        'c34e541dd8b742d993159dbebb094d8b',
-        'MD_COVID19_Case_Counts_by_County'
-      );
+      const dashboardId = 'c34e541dd8b742d993159dbebb094d8b';
+      const layerName = 'MD_COVID19_Case_Counts_by_County';
+      this.url = await fetch.getArcGISCSVURL('', dashboardId, layerName);
 
       const data = await fetch.csv(this.url);
       const counties = [];

--- a/src/shared/scrapers/US/SC/index.js
+++ b/src/shared/scrapers/US/SC/index.js
@@ -96,11 +96,9 @@ const scraper = {
       return counties;
     },
     '2020-03-25': async function() {
-      this.url = await fetch.getArcGISCSVURL(
-        2,
-        '3732035614af4246877e20c3a496e397',
-        'Covid19_Cases_Centroid_SharingView'
-      );
+      const dashboardId = '3732035614af4246877e20c3a496e397';
+      const layerName = 'Covid19_Cases_Centroid_SharingView';
+      this.url = await fetch.getArcGISCSVURL(2, dashboardId, layerName);
       const data = await fetch.csv(this.url);
       let counties = [];
       for (const county of data) {
@@ -118,11 +116,9 @@ const scraper = {
       return counties;
     },
     '2020-03-28': async function() {
-      this.url = await fetch.getArcGISCSVURL(
-        2,
-        '3732035614af4246877e20c3a496e397',
-        'COVID19_County_Polygon_SharingView2' // they started updating this view
-      );
+      const dashboardId = '3732035614af4246877e20c3a496e397';
+      const layerName = 'COVID19_County_Polygon_SharingView2'; // they started updating this view
+      this.url = await fetch.getArcGISCSVURL(2, dashboardId, layerName);
       const data = await fetch.csv(this.url);
       let counties = [];
       for (const county of data) {

--- a/src/shared/scrapers/US/TN/index.js
+++ b/src/shared/scrapers/US/TN/index.js
@@ -308,11 +308,10 @@ const scraper = {
         });
       });
 
-      const totalsData = (
-        await fetch.json(
-          'https://services1.arcgis.com/YuVBSS7Y1of2Qud1/ArcGIS/rest/services/TN_Covid_Total/FeatureServer/0/query?where=1%3D1&outFields=*&returnGeometry=false&f=pjson'
-        )
-      ).features.pop().attributes;
+      const totalsUrl =
+        'https://services1.arcgis.com/YuVBSS7Y1of2Qud1/ArcGIS/rest/services/TN_Covid_Total/FeatureServer/0/query?where=1%3D1&outFields=*&returnGeometry=false&f=pjson';
+      const tmp = await fetch.json(totalsUrl);
+      const totalsData = tmp.features.pop().attributes;
 
       const totals = transform.sumData(counties);
       totals.cases = totalsData.Total_Infections;

--- a/src/shared/scrapers/US/VT/index.js
+++ b/src/shared/scrapers/US/VT/index.js
@@ -57,9 +57,9 @@ const scraper = {
         });
       });
 
-      const totalsData = await fetch.json(
-        'https://services1.arcgis.com/BkFxaEFNwHqX3tAw/arcgis/rest/services/county_summary/FeatureServer/0/query?where=1%3D1&outFields=*&f=pjson'
-      );
+      const totalsurl =
+        'https://services1.arcgis.com/BkFxaEFNwHqX3tAw/arcgis/rest/services/county_summary/FeatureServer/0/query?where=1%3D1&outFields=*&f=pjson';
+      const totalsData = await fetch.json(totalsurl);
       const totals = transform.sumData(counties);
       totals.tested = totalsData.features.pop().attributes.total_tests;
 

--- a/src/shared/scrapers/ZA/index.js
+++ b/src/shared/scrapers/ZA/index.js
@@ -26,18 +26,15 @@ const scraper = {
   async scraper() {
     const date = datetime.getYYYYMMDD(process.env.SCRAPE_DATE);
 
-    const casesData = await fetch.csv(
-      'https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_confirmed.csv',
-      false
-    );
-    const deathsData = await fetch.csv(
-      'https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_timeline_deaths.csv',
-      false
-    );
-    const testedData = await fetch.csv(
-      'https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_timeline_testing.csv',
-      false
-    );
+    const casesUrl =
+      'https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_confirmed.csv';
+    const casesData = await fetch.csv(casesUrl, false);
+
+    const deathsUrl = 'https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_timeline_deaths.csv';
+    const deathsData = await fetch.csv(deathsUrl, false);
+
+    const testedUrl = 'https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_timeline_testing.csv';
+    const testedData = await fetch.csv(testedUrl, false);
 
     const dataByProvince = {};
     const nationalData = { tested: 0, deaths: 0, cases: 0 };

--- a/tests/unit/shared/scrapers/scrapers-all-test.js
+++ b/tests/unit/shared/scrapers/scrapers-all-test.js
@@ -2,6 +2,7 @@ const imports = require('esm')(module);
 const { join } = require('path');
 const test = require('tape');
 const fastGlob = require('fast-glob');
+const fs = require('fs');
 
 const shared = join(process.cwd(), 'src', 'shared');
 const lib = join(shared, 'lib');
@@ -29,4 +30,67 @@ test('scrapers-all-test: all scraper schema', async t => {
     t.notOk(hasErrors, `${s.name} schema ok`);
   }
   t.end();
+});
+
+const scraperCodeFiles = allJs.map(f => {
+  const content = fs.readFileSync(f, 'utf-8');
+  const m = content.match(/fetch\..*/g);
+  return {
+    shortName: f.replace(scraperRoot, '').trim(),
+    importsFetch: /fetch.*?index.js/.test(content),
+    fetchLines: m
+  };
+});
+
+function validateCodingConventions(t, lin) {
+  // Having the fetch all one line helps with code instrumentation
+  // (regex search-and-replace).
+  t.ok(lin.trim().endsWith(');'), `"${lin}" ends with ');'`);
+
+  /*
+  // DISABLING THESE CHECKS FOR NOW, WILL RE-ENABLE LATER.
+
+  // Each call should have the scraper object, the URL, and the
+  // "cache key".
+  // console.log(lin);
+  const fetchArgs = lin
+        .trim()
+        .replace(/.*\(/, '')
+        .replace(/\);$/, '')
+        .split(',')
+        .map(s => s.trim());
+  const lenMsg = `Expected >=3 args to fetch (scraper, url, cacheKey), got ${fetchArgs.length}`;
+  t.ok(fetchArgs.length >= 3, lenMsg);
+
+  if (fetchArgs.length >= 3) {
+    const first = fetchArgs[0];
+    const third = fetchArgs[2];
+
+    // First arg: Most scrapers can pass 'this', but some scrapers
+    // use helper functions, and so must pass 'obj'.
+    t.ok(first == 'this' || first == 'obj', 'first arg is this or obj');
+
+    // Third arg: Must be cache key.
+    const apos = "'";
+    const ckmsg = `third arg (${third}) is cache key, must be string`;
+    t.ok(third.startsWith(apos) && third.endsWith(apos), ckmsg);
+  }
+  */
+}
+
+const checkFiles = scraperCodeFiles.filter(scf => scf.importsFetch);
+
+checkFiles.forEach(scf => {
+  scf.fetchLines.forEach(lin => {
+    const testname = `${scf.shortName} fetch coding conventions (line "${lin}")`;
+    test(testname, async t => {
+      try {
+        validateCodingConventions(t, lin);
+      } catch (err) {
+        t.fail(err);
+      } finally {
+        t.end();
+      }
+    });
+  });
 });

--- a/tests/unit/shared/scrapers/scrapers-all-test.js
+++ b/tests/unit/shared/scrapers/scrapers-all-test.js
@@ -45,7 +45,18 @@ const scraperCodeFiles = allJs.map(f => {
 function validateCodingConventions(t, lin) {
   // Having the fetch all one line helps with code instrumentation
   // (regex search-and-replace).
-  t.ok(lin.trim().endsWith(');'), `"${lin}" ends with ');'`);
+  t.ok(lin.endsWith(');'), `"${lin}" ends with ');'`);
+
+  // Some places have fetch() within a larger expression, e.g.:
+  // const casesData = (await fetch.csv(this.url, false)).filter(...);
+  // Can't have that!
+  const fetchCheck = lin.match(/fetch.*?\(.*?\)(.*?);/);
+  if (fetchCheck) {
+    const afterParens = fetchCheck[1];
+    t.equal('', afterParens.trim(), 'Should be nothing after the first closing parens');
+  } else {
+    t.fail(`Doesn't follow convention`);
+  }
 
   /*
   // DISABLING THESE CHECKS FOR NOW, WILL RE-ENABLE LATER.


### PR DESCRIPTION
## Summary

This changes the layout of code in scrapers so that all of them are on a single line.  This will let me quickly change over all scrapers using a simple regex to a new API for fetch and get, which will _greatly_ help with cache migration.

In summary, any call to `fetch.XXXX(` must all be on one line, no breaks, no nesting of fetch and other code.  I've added a unit test to run on all scraper code that uses fetch.

I ran the reports on the latest master, and on this branch (rebased off of the same), and the reports were identical:

```
# On master:
$ yarn start --onlyUseCache -d 2020-4-13 --writeTo zzz0_master

# On this branch:
$ yarn start --onlyUseCache -d 2020-4-13 --writeTo zzz1_SingleLine

# Comparing:
$ node tools/compare-report-dirs.js --left zzz0_master --right zzz1_SingleLine

data-2020-4-13.json: equal
report.json: equal
ratings.json: equal
features-2020-4-13.json: equal
crawler-report.csv: equal
data-2020-4-13.csv: equal
```
