### PR TITLE
fix: IN hash in state name

### DIFF
--- a/src/shared/scrapers/IN/index.js
+++ b/src/shared/scrapers/IN/index.js
@@ -55,7 +55,7 @@ const countryLevelMap = {
 
 const getValue = (key, text) => {
   if (key === 'state') {
-    const state = parse.string(text);
+    const state = parse.string(text).replace(/#/, '');
     const mappedState = countryLevelMap[state];
     assert(
       mappedState,


### PR DESCRIPTION
Strip out any `#`s before mapping the state name to ID