### PR TITLE
fix: ZA

### DIFF
--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -92,7 +92,10 @@ export const csv = async (url, date, options = {}) => {
       resolve(null);
     } else {
       csvParse(
-        resp.body,
+        resp.body
+          // Remove blank lines at the end of the document, this break CSV parsing
+          // regex from https://stackoverflow.com/a/16369725/2034508
+          .replace(/^\s*$(?:\r\n?|\n)/gm, ''),
         {
           delimiter: options.delimiter,
           columns: true


### PR DESCRIPTION
This PR fixes ZA, which had a CSV parsing failure. The CSV provided by the ZA community project included 3 blank lines at the end of the document. I modified the CSV fetch script to remove empty lines at the beginning and end of documents to address this issue.