### PR TITLE
fix: deprecate failing US/CA county scrapers

### DIFF
--- a/src/shared/scrapers/US/CA/alameda-county.js
+++ b/src/shared/scrapers/US/CA/alameda-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -19,11 +20,17 @@ const scraper = {
   headless: true,
   type: 'paragraph',
   maintainers: [maintainers.jbencina],
-  async scraper() {
-    const $ = await fetch.headless(this.url);
-    const $el = $('p:contains("Positive Cases")');
-    const matches = $el.html().match(/Positive Cases:.*?(\d+).*/);
-    return { cases: parse.number(matches[1]) };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.headless(this.url);
+      const $el = $('p:contains("Positive Cases")');
+      const matches = $el.html().match(/Positive Cases:.*?(\d+).*/);
+      return { cases: parse.number(matches[1]) };
+    },
+    '2020-04-15': async function() {
+      await fetch.headless(this.url);
+      throw new DeprecatedError('Sunsetting county level scrapers');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/calaveras-county.js
+++ b/src/shared/scrapers/US/CA/calaveras-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,15 +12,21 @@ const scraper = {
   country: 'iso1:US',
   url: 'https://covid19.calaverasgov.us/',
   maintainers: [maintainers.jbencina],
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const cases = parse.number(
-      $('h2:contains("in Calaveras County:")')
-        .first()
-        .text()
-        .match(/in Calaveras County: (\d+)/)[1]
-    );
-    return { cases };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const cases = parse.number(
+        $('h2:contains("in Calaveras County:")')
+          .first()
+          .text()
+          .match(/in Calaveras County: (\d+)/)[1]
+      );
+      return { cases };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county level scrapers');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/del-norte-county.js
+++ b/src/shared/scrapers/US/CA/del-norte-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -62,6 +63,10 @@ const scraper = {
         cases,
         tested
       };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county level scraper');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/glenn-county.js
+++ b/src/shared/scrapers/US/CA/glenn-county.js
@@ -30,7 +30,7 @@ const scraper = {
       $('span:contains("Glenn County COVID-19 Cases")')
         .first()
         .text()
-        .match(/Cases: (\d+)/)[1]
+        .match(/Cases:.*(\d+)/)[1]
     );
     return { cases };
   }

--- a/src/shared/scrapers/US/CA/kern-county.js
+++ b/src/shared/scrapers/US/CA/kern-county.js
@@ -1,5 +1,6 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -42,7 +43,7 @@ const scraper = {
       return { cases, tested };
     },
     '2020-03-23': async function() {
-      throw new Error('Kern County, CA now uses a PNG and PDF');
+      throw new DeprecatedError('Kern County, CA now uses a PNG and PDF');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/madera-county.js
+++ b/src/shared/scrapers/US/CA/madera-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,11 +12,16 @@ const scraper = {
   country: 'iso1:US',
   maintainers: [maintainers.jbencina],
   url: 'https://www.maderacounty.com/government/public-health/health-updates/corona-virus',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const $el = $('*:contains("Confirmed cases")').first();
-    const matches = $el.text().match(/Confirmed cases:.*?(\d+)/);
-    return { cases: parse.number(matches[1]) };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const $el = $('*:contains("Confirmed cases")').first();
+      const matches = $el.text().match(/Confirmed cases:.*?(\d+)/);
+      return { cases: parse.number(matches[1]) };
+    },
+    '2020-04-04': async function() {
+      throw new DeprecatedError('Madera County, CA now uses a PNG');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/marin-county.js
+++ b/src/shared/scrapers/US/CA/marin-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,11 +12,17 @@ const scraper = {
   country: 'iso1:US',
   maintainers: [maintainers.jbencina],
   url: 'https://coronavirus.marinhhs.org/surveillance',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const text = $('td:contains("confirmed cases of COVID-19")').text();
-    const cases = parse.number(text.match(/there have been (\d+) confirmed cases of/)[1]);
-    return { cases };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const text = $('td:contains("confirmed cases of COVID-19")').text();
+      const cases = parse.number(text.match(/there have been (\d+) confirmed cases of/)[1]);
+      return { cases };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county level scrapers');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/mendocino-county.js
+++ b/src/shared/scrapers/US/CA/mendocino-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -33,6 +34,10 @@ const scraper = {
       const $li = $outerLI.find('li:contains("Total Positives")');
       const cases = parse.number($li.text().split(':')[1]);
       return { cases };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county level scrapers');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/merced-county.js
+++ b/src/shared/scrapers/US/CA/merced-county.js
@@ -2,6 +2,7 @@ import cheerioTableparser from 'cheerio-tableparser';
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -69,6 +70,10 @@ const scraper = {
         deaths: parse.number(data[1][3]),
         recoveries: parse.number(data[1][4])
       };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county level scrapers');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/orange-county.js
+++ b/src/shared/scrapers/US/CA/orange-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -30,7 +31,7 @@ const scraper = {
     '2020-03-18': async function scraper() {
       this.url = 'https://occovid19.ochealthinfo.com/coronavirus-in-oc';
       await fetch.page(this.url);
-      throw new Error('Need to scrape new page');
+      throw new DeprecatedError('Need to scrape new page');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/riverside-county.js
+++ b/src/shared/scrapers/US/CA/riverside-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,11 +12,17 @@ const scraper = {
   country: 'iso1:US',
   maintainers: [maintainers.jbencina],
   url: 'https://www.rivcoph.org/coronavirus',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const $el = $('p:contains("Confirmed cases:")').first();
-    const matches = $el.text().match(/Confirmed cases:.*?(\d+)/);
-    return { cases: parse.number(matches[1]) };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const $el = $('p:contains("Confirmed cases:")').first();
+      const matches = $el.text().match(/Confirmed cases:.*?(\d+)/);
+      return { cases: parse.number(matches[1]) };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county scraper');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/sacramento-county.js
+++ b/src/shared/scrapers/US/CA/sacramento-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,14 +12,20 @@ const scraper = {
   country: 'iso1:US',
   maintainers: [maintainers.jbencina],
   url: 'https://www.saccounty.net/COVID-19/Pages/default.aspx',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const $table = $('th:contains("Confirmed")').closest('table');
-    const $tds = $table.find('tr:nth-child(2) > td');
-    return {
-      cases: parse.number($tds.first().text()),
-      deaths: parse.number($tds.last().text())
-    };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const $table = $('th:contains("Confirmed")').closest('table');
+      const $tds = $table.find('tr:nth-child(2) > td');
+      return {
+        cases: parse.number($tds.first().text()),
+        deaths: parse.number($tds.last().text())
+      };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county scraper');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/san-benito-county.js
+++ b/src/shared/scrapers/US/CA/san-benito-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -39,7 +40,7 @@ const scraper = {
       };
     },
     '2020-03-19': async function scraper() {
-      throw new Error('Need to scrape new arcgis');
+      throw new DeprecatedError('Need to scrape new arcgis');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/san-bernardino-county.js
+++ b/src/shared/scrapers/US/CA/san-bernardino-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,14 +12,20 @@ const scraper = {
   country: 'iso1:US',
   maintainers: [maintainers.jbencina],
   url: 'http://wp.sbcounty.gov/dph/coronavirus/',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const cases = parse.number(
-      $('h3:contains("COVID-19 CASES")')
-        .parent()
-        .attr('data-number-value')
-    );
-    return { cases };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const cases = parse.number(
+        $('h3:contains("COVID-19 CASES")')
+          .parent()
+          .attr('data-number-value')
+      );
+      return { cases };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county scraper');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/santa-barbara-county.js
+++ b/src/shared/scrapers/US/CA/santa-barbara-county.js
@@ -2,6 +2,7 @@ import cheerioTableparser from 'cheerio-tableparser';
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -56,6 +57,10 @@ const scraper = {
       const tested = parse.number(data[1][lastRow]);
 
       return { cases, tested };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county scraper');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/santa-clara-county.js
+++ b/src/shared/scrapers/US/CA/santa-clara-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,17 +12,23 @@ const scraper = {
   country: 'iso1:US',
   maintainers: [maintainers.jbencina],
   url: 'https://www.sccgov.org/sites/phd/DiseaseInformation/novel-coronavirus/Pages/home.aspx',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const scriptData = $('script:contains("Total_Confirmed_Cases")')[0].children[0].data;
-    const regExp = /\[.*\]/;
-    const data = JSON.parse(regExp.exec(scriptData))[0];
-    const cases = parse.number(data.Total_Confirmed_Cases);
-    const deaths = parse.number(data.Deaths);
-    return {
-      cases,
-      deaths
-    };
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const scriptData = $('script:contains("Total_Confirmed_Cases")')[0].children[0].data;
+      const regExp = /\[.*\]/;
+      const data = JSON.parse(regExp.exec(scriptData))[0];
+      const cases = parse.number(data.Total_Confirmed_Cases);
+      const deaths = parse.number(data.Deaths);
+      return {
+        cases,
+        deaths
+      };
+    },
+    '2020-05-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county scraper');
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/santa-cruz-county.js
+++ b/src/shared/scrapers/US/CA/santa-cruz-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -11,14 +12,20 @@ const scraper = {
   country: 'iso1:US',
   maintainers: [maintainers.jbencina],
   url: 'http://www.santacruzhealth.org/HSAHome/HSADivisions/PublicHealth/CommunicableDiseaseControl/Coronavirus.aspx',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    const $h2 = $('p:contains("Total Confirmed Cases")').nextAll('h2');
-    if ($h2.html() === null) {
-      throw new Error('H2 not found');
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      const $h2 = $('p:contains("Total Confirmed Cases")').nextAll('h2');
+      if ($h2.html() === null) {
+        throw new Error('H2 not found');
+      }
+      const cases = parse.number($h2.text());
+      return { cases };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Moved to Tableau');
     }
-    const cases = parse.number($h2.text());
-    return { cases };
   }
 };
 

--- a/src/shared/scrapers/US/CA/solano-county.js
+++ b/src/shared/scrapers/US/CA/solano-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -30,7 +31,7 @@ const scraper = {
       return { cases, deaths };
     },
     '2020-03-24': async function() {
-      throw new Error('Solano County, CA now uses a PDF');
+      throw new DeprecatedError('Solano County, CA now uses a PDF');
     }
   }
 };

--- a/src/shared/scrapers/US/CA/yolo-county.js
+++ b/src/shared/scrapers/US/CA/yolo-county.js
@@ -2,6 +2,7 @@ import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import datetime from '../../../lib/datetime/index.js';
 import maintainers from '../../../lib/maintainers.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -13,16 +14,22 @@ const scraper = {
   maintainers: [maintainers.jbencina],
   url:
     'https://www.yolocounty.org/health-human-services/adults/communicable-disease-investigation-and-control/novel-coronavirus-2019',
-  async scraper() {
-    const $ = await fetch.page(this.url);
-    if (datetime.scrapeDateIsBefore('2020-03-17')) {
+  scraper: {
+    '0': async function() {
+      const $ = await fetch.page(this.url);
+      if (datetime.scrapeDateIsBefore('2020-03-17')) {
+        const $h3 = $('h3:contains("confirmed case")');
+        const matches = $h3.text().match(/there are (\d+) confirmed cases? in Yolo/);
+        return { cases: parse.number(matches[1]) };
+      }
       const $h3 = $('h3:contains("confirmed case")');
-      const matches = $h3.text().match(/there are (\d+) confirmed cases? in Yolo/);
+      const matches = $h3.text().match(/(\d+) confirmed case/);
       return { cases: parse.number(matches[1]) };
+    },
+    '2020-04-15': async function() {
+      await fetch.page(this.url);
+      throw new DeprecatedError('Sunsetting county scraper');
     }
-    const $h3 = $('h3:contains("confirmed case")');
-    const matches = $h3.text().match(/(\d+) confirmed case/);
-    return { cases: parse.number(matches[1]) };
   }
 };
 


### PR DESCRIPTION
This PR deprecates currently failing US/CA county scrapers. I am proposing this change as I do not see us having the capacity to maintain these scrapers and we already have aggregate sources covering the state of California. I am still allowing the scraper to cache their URL in case we are able to revisit these sources at a later date.
