### PR TITLE
Update country-levels to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ajv": "^6.12.0",
     "cheerio": "^1.0.0-rc.3",
     "cheerio-tableparser": "^1.0.1",
-    "country-levels": "https://github.com/hyperknot/country-levels/releases/download/v1.8.0/export_q7.tgz",
+    "country-levels": "https://github.com/hyperknot/country-levels/releases/download/v2.0.0/export_medium.tgz",
     "csv-parse": "^4.8.8",
     "csv-stringify": "^5.3.6",
     "d3-color": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,9 +1431,9 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-"country-levels@https://github.com/hyperknot/country-levels/releases/download/v1.8.0/export_q7.tgz":
+"country-levels@https://github.com/hyperknot/country-levels/releases/download/v2.0.0/export_medium.tgz":
   version "1.0.0"
-  resolved "https://github.com/hyperknot/country-levels/releases/download/v1.8.0/export_q7.tgz#ab3b2ddd890d74c6a7e2cc273319bee1fe58c6c3"
+  resolved "https://github.com/hyperknot/country-levels/releases/download/v2.0.0/export_medium.tgz#ed8cb4972043634a720a540a56a6c8687b9ceebb"
 
 cpr@~3.0.1:
   version "3.0.1"


### PR DESCRIPTION
New major version using a much better GeoJSON simplification. 

features.json down from 50 MB to 15 MB!

By converting it to TopoJSON later on, we can make it to 5 MB, which is only 1.7 MB gzipped (all countries, states and counties together!)

timeseries.csv is the same as in master, except for some lower digit differences in center coordinates.
map is visually the same as in master.