### PR TITLE
scrape more of AU VIC data from paragraphs

### DIFF
--- a/src/shared/scrapers/AU/VIC/tests/expected.2020-04-21.json
+++ b/src/shared/scrapers/AU/VIC/tests/expected.2020-04-21.json
@@ -1,3 +1,5 @@
 {
-  "cases": 1336
+  "cases": 1336,
+  "deaths": 15,
+  "recovered": 1202
 }


### PR DESCRIPTION
Seems like its standardised a bit now, so this mostly works. We have a good cache of these so we may as well extract what we can.