### PR TITLE
Use COVIDTracking for US states

### DIFF
--- a/src/shared/scrapers/US/covidtracking.js
+++ b/src/shared/scrapers/US/covidtracking.js
@@ -19,7 +19,7 @@ const scraper = {
   ],
   scraperTz: 'America/Los_Angeles',
   aggregate: 'state',
-  priority: -0.5,
+  priority: 100,
   async scraper() {
     const data = await fetch.json(this, this.url, 'default');
 


### PR DESCRIPTION
For US states, COVIDTracking provides a higher quality source than anything else. We should use it for state level over anything else.

This fixes the issue with NY #823 as well as possibly many other issues with states.

