### PR TITLE
Fix VA cache keys.

### DIFF
--- a/src/shared/lib/fetch/cache-migration.js
+++ b/src/shared/lib/fetch/cache-migration.js
@@ -81,11 +81,21 @@ function checkCacheKeyCollision(cacheKey, destdir) {
   throw new Error(msg);
 }
 
+function checkCacheKey(s) {
+  const check = /^[a-z]+$/;
+  if (check.test(s) !== true) {
+    throw new Error(`Bad cache key ${s}`);
+  }
+}
+
 // Migrate the file to a temp folder.
 // New format:
 // crawler-cache/us-ca-xx-county/2020-04-12/2020-04-12t00_47_14.145z-default-344b7.html
 export function migrateFile(url, filePath, encoding, scraper, date, cacheKey, type) {
   console.log(`MIGRATING ${filePath}`);
+
+  checkCacheKey(cacheKey);
+
   const topdir = newTopFolder(scraper._path);
   const formattedDate = datetimeFormatting.getYYYYMMDD(date);
   const dt = spacetime(formattedDate)

--- a/src/shared/scrapers/US/VA/index.js
+++ b/src/shared/scrapers/US/VA/index.js
@@ -221,13 +221,23 @@ const scraper = {
       ];
       this.type = 'pdf';
 
+      const makeCacheKey = s => {
+        const ret = s.toLowerCase().replace(/ /g, '');
+        const check = /^[a-z]+$/;
+        if (check.test(ret) !== true) {
+          throw new Error(`Bad cache key ${ret}`);
+        }
+        return ret;
+      };
+
       for (const name of this._counties) {
         let endURL = name;
         if (!fullNameCounties.includes(name)) {
           endURL = endURL.slice(0, name.lastIndexOf(' '));
         }
         const pdfUrl = pdfBaseURL + endURL;
-        const pdfScrape = await fetch.pdf(this, pdfUrl, endURL);
+        const ck = makeCacheKey(endURL);
+        const pdfScrape = await fetch.pdf(this, pdfUrl, ck);
 
         if (pdfScrape) {
           let pdfText = '';


### PR DESCRIPTION
Fix cache migration, VA was creating bad cache key names.

Prior:

`2020-03-23t04_00_00.000z-Virginia Beach-888b1.pdf`

Fixed to:

`2020-03-23t04_00_00.000z-virginiabeach-888b1.pdf`

Can regen the cache for this with:

`node tools/generate-v1-cache.js --location US/VA/index.js -d zz-regen-us-va`