### PR TITLE
Add dumpRaw for regression testing with li.

### DIFF
--- a/src/events/processor/write-data/dump-regression-raw.js
+++ b/src/events/processor/write-data/dump-regression-raw.js
@@ -2,6 +2,8 @@ import path from 'path';
 import * as fs from '../../../shared/lib/fs.js';
 
 const writeRawRegression = async args => {
+  if (!args.options.dumpRaw) return args;
+
   let suffix = '';
   if (args.options.outputSuffix !== undefined) {
     suffix = args.options.outputSuffix;

--- a/src/events/processor/write-data/dump-regression-raw.js
+++ b/src/events/processor/write-data/dump-regression-raw.js
@@ -1,0 +1,68 @@
+import path from 'path';
+import * as fs from '../../../shared/lib/fs.js';
+
+const writeRawRegression = async args => {
+  let suffix = '';
+  if (args.options.outputSuffix !== undefined) {
+    suffix = args.options.outputSuffix;
+  } else if (process.env.SCRAPE_DATE) {
+    suffix = `-${process.env.SCRAPE_DATE}`;
+  }
+
+  const d = args.options.writeTo;
+  await fs.ensureDir(d);
+
+  const data = args.locations;
+  const keyCollector = data.reduce((hsh, val) => {
+    return { ...hsh, ...val };
+  }, {});
+  await fs.writeJSON(path.join(d, `raw-keys${suffix}.json`), Object.keys(keyCollector), { space: 2 });
+
+  // Only pull out a subset of the data for each location.  Since
+  // some scrapers put 'null' or 'undefined' for data, do a check to
+  // see if the given key is in the returned set of keys.
+  const useKeys = [
+    '_path',
+    'active',
+    'aggregate',
+    'cases',
+    'certValidation',
+    'city',
+    'country',
+    'county',
+    'date',
+    'deaths',
+    'discard',
+    'discharged',
+    'hospitalized',
+    'icu',
+    'population',
+    'priority',
+    'recoverd',
+    'recovered',
+    'state',
+    'tested',
+    'tests',
+    'timeseries',
+    'todayHospitalized'
+  ];
+
+  const output = data.map(d => {
+    // console.log(`Pruning ${d}`);
+    // console.log(`Keys for it: ${Object.keys(d)}`);
+    const pruned = {};
+    for (const k of Object.keys(d)) {
+      // console.log(`  Checking key: ${k}`)
+      if (useKeys.includes(k)) {
+        // console.log(`  Found key: ${k}`)
+        pruned[k] = d[k];
+      }
+    }
+    return pruned;
+  });
+  await fs.writeJSON(path.join(d, `raw${suffix}.json`), output, { space: 2 });
+
+  return args;
+};
+
+export default writeRawRegression;

--- a/src/shared/cli/cli-args.js
+++ b/src/shared/cli/cli-args.js
@@ -26,6 +26,11 @@ const { argv } = yargs
     description: 'The suffix to add to output files, i.e. passing TEST will produce data-TEST.json etc',
     type: 'string'
   })
+  .option('dumpRaw', {
+    alias: 'r',
+    description: 'Dump raw scrape response data to dist for regression testing',
+    type: 'boolean'
+  })
   .option('quiet', {
     alias: 'q',
     description: 'Suppress logs',

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -33,7 +33,7 @@ async function generate(date, options = {}) {
 
   // Crawler
   const output = scrapeData(srcs)
-    .then(options.dumpRaw !== false && writeRawRegression)
+    .then(writeRawRegression)
     // processor
     .then(rateSources)
     .then(dedupeLocations)

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,6 +1,7 @@
 // Crawler operations
 import fetchSources from '../events/crawler/get-sources/index.js';
 import scrapeData from '../events/crawler/scrape-data/index.js';
+import writeRawRegression from '../events/processor/write-data/dump-regression-raw.js';
 
 // Metadata + geo processing operations
 import rateSources from '../events/processor/rate-sources/index.js';
@@ -32,6 +33,7 @@ async function generate(date, options = {}) {
 
   // Crawler
   const output = scrapeData(srcs)
+    .then(options.dumpRaw !== false && writeRawRegression)
     // processor
     .then(rateSources)
     .then(dedupeLocations)


### PR DESCRIPTION


## Summary

This dumps raw scraped data to a new report, `raw.json`, stored in dist.

Sample output: 

```
[
  {
    "_path": "/Users/jeff/Documents/Projects/coronadatascraper/src/shared/scrapers/US/CA/san-diego-county.js",
    "county": "fips:06073",
    "state": "iso2:US-CA",
    "country": "iso1:US",
    "timeseries": false,
    "certValidation": true,
    "priority": 0,
    "cases": 2943,
    "deaths": 111
  }
]
```

The new routine only includes out a handfull of fields from the raw scraper data in the report, and the resulting file is ~ 3 mb.

With this output, we can work on getting regression testing in place for corresponding sources in li.

## Changes

* added `--dumpRaw` to options, eg `yarn start --dumpRaw`.  The raw report isn't written if that's not set.
