### PR TITLE
Fix broken BR scraper.

### DIFF
--- a/src/shared/scrapers/BR/index.js
+++ b/src/shared/scrapers/BR/index.js
@@ -122,9 +122,12 @@ const scraper = {
       entries.each(function() {
         const entry = $(this);
         const name = findOne(entry, '.lb-nome.nome').text();
-        const titles = findOne(entry, '.header-list.tp-aux');
-        if (titles.text().trim() !== 'ConfirmadosÓbitosIncidênciaLetalidade')
-          throw new Error('Text did not match expected titles');
+        const titles = findOne(entry, '.header-list.tp-aux')
+          .text()
+          .trim();
+        const expectedTitles = 'ConfirmadosÓbitosIncidênciaLetalidade';
+        if (titles !== expectedTitles)
+          throw new Error(`Title text (${titles}) did not match expected ${expectedTitles}`);
         const ufsEntry = ufs[name];
         if (!ufsEntry) throw new Error(`Unknown name ${name}, not in this._ufs`);
         const iso = ufsEntry[0];

--- a/src/shared/scrapers/BR/index.js
+++ b/src/shared/scrapers/BR/index.js
@@ -57,44 +57,111 @@ const scraper = {
     'São Paulo': ['iso2:BR-SP', 45919049, [-23.5505, -46.6333]],
     Tocantins: ['iso2:BR-TO', 1572866, [-10.1753, -48.2982]]
   },
-  async scraper() {
-    const response = [];
-    const ufs = this._ufs;
-    const $ = await fetch.headless(this, this.url, 'default');
+  scraper: {
+    '0': async function scraper() {
+      const response = [];
+      const ufs = this._ufs;
+      const $ = await fetch.headless(this, this.url, 'default');
 
-    $.root()
-      .find('.list-itens .teste')
-      .each(function() {
-        const uf = $(this)
-          .prev()
-          .text();
+      $.root()
+        .find('.list-itens .teste')
+        .each(function() {
+          const uf = $(this)
+            .prev()
+            .text();
+
+          response.push({
+            state: ufs[uf][0],
+            cases: parseInt(
+              $(this)
+                .find('.lb-nome')
+                .eq(0)
+                .text(),
+              10
+            ),
+            deaths: parseInt(
+              $(this)
+                .find('.lb-nome')
+                .eq(1)
+                .text(),
+              10
+            ),
+            population: ufs[uf][1],
+            coordinates: [ufs[uf][2][1], ufs[uf][2][0]],
+            aggregate: 'state'
+          });
+        });
+
+      response.push(transform.sumData(response, { aggregate: 'state' }));
+
+      return response;
+    },
+
+    // TODO: things actually started busting before this point .. adjust this date as we figure out where it actually works.
+    '2020-04-28': async function scraper() {
+      const $ = await fetch.headless(this, this.url, 'default');
+      const ufs = this._ufs;
+
+      // Find entries, throws if doesn't find at least one.
+      const findMany = (el, selector) => {
+        const ret = el.find(selector);
+        if (ret.length === 0) throw new Error(`No match for ${selector}`);
+        return ret;
+      };
+
+      // Find entry, throws if not exactly one.
+      const findOne = (el, selector) => {
+        const ret = findMany(el, selector);
+        if (ret.length !== 1) throw new Error(`Should have 1 match for ${selector}, got ${ret.length}`);
+        return ret;
+      };
+
+      const response = [];
+
+      const entries = findMany($.root(), '.item-line');
+      entries.each(function() {
+        const entry = $(this);
+        const name = findOne(entry, '.lb-nome.nome').text();
+        const titles = findOne(entry, '.header-list.tp-aux');
+        if (titles.text().trim() !== 'ConfirmadosÓbitosIncidênciaLetalidade')
+          throw new Error('Text did not match expected titles');
+        const ufsEntry = ufs[name];
+        if (!ufsEntry) throw new Error(`Unknown name ${name}, not in this._ufs`);
+        const iso = ufsEntry[0];
+        const population = ufsEntry[1];
+        const coordinates = [ufsEntry[2][1], ufsEntry[2][0]];
+
+        const values = findMany(entry, '.lb-nome.lb-value');
+        const d = [];
+        values.each(function() {
+          const v = parseInt(
+            $(this)
+              .text()
+              .trim(),
+            10
+          );
+          d.push(v);
+        });
+        // The headings (translated) are: Confirmed, Deaths, Incidence, Letality.
+        // I'm not sure what the last two are, so will only include Confirmed and Deaths.
+        const cases = d[0];
+        const deaths = d[1];
 
         response.push({
-          state: ufs[uf][0],
-          cases: parseInt(
-            $(this)
-              .find('.lb-nome')
-              .eq(0)
-              .text(),
-            10
-          ),
-          deaths: parseInt(
-            $(this)
-              .find('.lb-nome')
-              .eq(1)
-              .text(),
-            10
-          ),
-          population: ufs[uf][1],
-          coordinates: [ufs[uf][2][1], ufs[uf][2][0]],
+          state: iso,
+          cases,
+          deaths,
+          population,
+          coordinates,
           aggregate: 'state'
         });
       });
 
-    response.push(transform.sumData(response, { aggregate: 'state' }));
+      response.push(transform.sumData(response, { aggregate: 'state' }));
 
-    return response;
-  }
+      return response;
+    } // end 2020-04-28
+  } // end scraper
 };
 
 export default scraper;

--- a/src/shared/scrapers/BR/index.js
+++ b/src/shared/scrapers/BR/index.js
@@ -125,9 +125,9 @@ const scraper = {
         const titles = findOne(entry, '.header-list.tp-aux')
           .text()
           .trim();
-        const expectedTitles = 'ConfirmadosÓbitosIncidênciaLetalidade';
-        if (titles !== expectedTitles)
-          throw new Error(`Title text (${titles}) did not match expected ${expectedTitles}`);
+        const expectedTitles = new RegExp('CasosÓbitos.*');
+        if (!expectedTitles.test(titles))
+          throw new Error(`Title text (${titles}) did not match expected regex ${expectedTitles}`);
         const ufsEntry = ufs[name];
         if (!ufsEntry) throw new Error(`Unknown name ${name}, not in this._ufs`);
         const iso = ufsEntry[0];


### PR DESCRIPTION
## Summary

Fixes, seems like it works.

Haven't tried to generalize any libs or anything, just getting the current thing to work.

lint and unit tests pass, runs locally and looks good:

`$ yarn start --location BR`: 

```
✅ Data scraped!
   - 0 cities
   - 27 states
   - 0 counties
   - 1 countries
ℹ️  Total counts (tracked cases, may contain duplicates):
   - 143772 cases
   - 0 tested
   - 0 recovered
   - 10034 deaths
   - 0 active
```

```
data:

  {
    "country": "Brazil",
    "sources": [
      {
        "description": "Secretaria de Vigilância em Saúde do Ministério da Saúde",
        "name": "SVS-MS",
        "url": "https://covid.saude.gov.br/"
      }
    ],
    "url": "https://covid.saude.gov.br/",
    "maintainers": [
      {
        "name": "Felipe Roberto",
        "email": "contato@feliperoberto.com.br",
        "url": "http://feliperoberto.com.br",
        "github": "feliperoberto",
        "country": "iso1:BR",
        "flag": "🇧🇷"
      }
    ],
    "state": "Acre",
    "cases": 311,
    "deaths": 16,
    "population": 881935,
    "coordinates": [
      -70.3015,
      -9.13
    ],
    "aggregate": "state",
    "rating": 0.5098039215686274,
    "tz": [
      "America/Rio_Branco"
    ],
    "featureId": "iso2:BR-AC",
    "countryId": "iso1:BR",
    "stateId": "iso2:BR-AC",
    "name": "Acre, Brazil",
    "level": "state"
  },
```

matches the data on the page.