### PR TITLE
Fixed current GA scraper.

### DIFF
--- a/src/shared/scrapers/US/GA/index.js
+++ b/src/shared/scrapers/US/GA/index.js
@@ -244,7 +244,6 @@ const scraper = {
       return counties;
     },
     '2020-04-28': async function() {
-
       // Find entries, throws if doesn't find at least one.
       const findMany = (el, selector) => {
         const ret = el.find(selector);

--- a/src/shared/scrapers/US/GA/index.js
+++ b/src/shared/scrapers/US/GA/index.js
@@ -242,6 +242,72 @@ const scraper = {
       counties = geography.addEmptyRegions(counties, this._counties, 'county');
 
       return counties;
+    },
+    '2020-04-28': async function() {
+
+      // Find entries, throws if doesn't find at least one.
+      const findMany = (el, selector) => {
+        const ret = el.find(selector);
+        if (ret.length === 0) throw new Error(`No match for ${selector}`);
+        return ret;
+      };
+
+      const sasurl = 'https://ga-covid19.ondemand.sas.com/';
+      // The site uses React/Material UI, so have to use a headless
+      // browser to get everything.
+      const $ = await fetch.headless(this, sasurl, 'default');
+
+      // Find the table with the headings we want.
+      const desiredHeadings = 'County, Confirmed Cases, Cases per 100K, Total Deaths, Hospitalizations';
+      const allTables = findMany($.root(), '.MuiTable-root.MuiTable-stickyHeader');
+      let countiesTable = null;
+      allTables.each(function() {
+        const t = $(this);
+        const headings = findMany(t, 'thead > tr > th')
+          .toArray()
+          .map(th => {
+            return $(th).text();
+          });
+        if (headings.join(', ') === desiredHeadings) {
+          countiesTable = t;
+        }
+      });
+
+      if (!countiesTable) throw new Error(`Couldn't find table with desired headings ${desiredHeadings})`);
+
+      let results = [];
+
+      // Hold on to reference to use it in an internal function.
+      const myCountyMap = this._countyMap;
+      findMany(countiesTable, 'tbody > tr').each(function() {
+        const tr = $(this);
+        const cells = findMany(tr, 'td')
+          .toArray()
+          .map(th => {
+            return $(th).text();
+          });
+        if (cells.length !== 5) {
+          throw new Error(`Expected 5 cells, got ${cells.length}`);
+        }
+
+        let name = cells[0];
+        name = myCountyMap[name] || name;
+        let county = geography.addCounty(parse.string(name));
+        if (['Unknown County', 'Non-Georgia Resident County'].includes(county)) {
+          county = UNASSIGNED;
+        }
+
+        const cases = parse.number(cells[1]);
+        const deaths = parse.number(cells[3]);
+        const hospitalized = parse.number(cells[4]);
+
+        results.push({ county, cases, deaths, hospitalized });
+      });
+
+      results.push(transform.sumData(results));
+      results = geography.addEmptyRegions(results, this._counties, 'county');
+
+      return results;
     }
   }
 };

--- a/src/shared/scrapers/US/GA/index.js
+++ b/src/shared/scrapers/US/GA/index.js
@@ -251,10 +251,10 @@ const scraper = {
         return ret;
       };
 
-      const sasurl = 'https://ga-covid19.ondemand.sas.com/';
+      this.url = 'https://ga-covid19.ondemand.sas.com/';
       // The site uses React/Material UI, so have to use a headless
       // browser to get everything.
-      const $ = await fetch.headless(this, sasurl, 'default');
+      const $ = await fetch.headless(this, this.url, 'default');
 
       // Find the table with the headings we want.
       const desiredHeadings = 'County, Confirmed Cases, Cases per 100K, Total Deaths, Hospitalizations';


### PR DESCRIPTION
GA changed their site to use React, and no longer have the "cloudfront" in the first index page.

The caching code would have failed entirely yesterday, so I don't think we have any cache for it.

Running locally, everything looks good:

```
$ yarn start --location US/GA; echo '----------------------'; tail -n 30 dist/data.json
...

----------------------
    "state": "Georgia",
    "country": "United States",
    "url": "https://dph.georgia.gov/covid-19-daily-status-report",
    "aggregate": "county",
    "sources": [
      {
        "url": "https://dph.georgia.gov",
        "name": "Georgia Department of Public Health"
      }
    ],
    "cases": 23928,
    "deaths": 1023,
    "hospitalized": 4898,
    "rating": 0.39215686274509803,
    "coordinates": [
      -83.2225,
      32.6795
    ],
    "tz": [
      "America/New_York"
    ],
    "featureId": "iso2:US-GA",
    "population": 10617423,
    "populationDensity": 69.53563936285731,
    "countryId": "iso1:US",
    "stateId": "iso2:US-GA",
    "name": "Georgia, United States",
    "level": "state"
  }
```

The section 

```
    "cases": 23928,
    "deaths": 1023,
    "hospitalized": 4898,
```

matches what's currently on the site https://dph.georgia.gov/covid-19-daily-status-report (when you sum everything up).