### PR TITLE
Fix US/RI scraper.

### DIFF
--- a/src/shared/scrapers/US/RI/index.js
+++ b/src/shared/scrapers/US/RI/index.js
@@ -4,6 +4,8 @@ import * as parse from '../../../lib/parse.js';
 import * as transform from '../../../lib/transform.js';
 import * as geography from '../../../lib/geography/index.js';
 
+const assert = require('assert');
+
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
 
@@ -172,6 +174,184 @@ const scraper = {
 
       // Add in cities
       regions = regions.concat(cities);
+
+      return regions;
+    },
+    '2020-04-29': async function() {
+      // The main RI site https://health.ri.gov/data/covid-19/ loads
+      // and then appears to make an Ajax call to load another
+      // iframe. The main page also has some data, but the iframe's
+      // data appears -- to me (jz) -- to be more up-to-date, so we're
+      // only going to scrape the iframe source.
+      //
+      // TODO DURING PORT: add "Inconsistent page data: only scraping
+      // iframe" to crawl caveats.
+
+      // Get the internal iframe URL from the containing page.
+      this.url = 'https://health.ri.gov/data/covid-19/';
+      const tmp = await fetch.page(this, this.url, 'tmpindex');
+      const iframeUrlRE = /\[\{"component":\{"name":"iframe-card","settings":\{"src":"(.*?)"/;
+      const m = tmp.html().match(iframeUrlRE);
+      if (!m) {
+        throw new Error(`Couldn't find actual URL, no match for ${iframeUrlRE}`);
+      }
+      const actualUrl = m[1];
+      // console.log(`Loading actual URL ${actualUrl}`);
+
+      this.headless = true;
+      const $ = await fetch.headless(this, actualUrl, 'default');
+      // console.log($.html());
+
+      // Find entries, throws if doesn't find at least one.
+      const findMany = (el, selector) => {
+        const ret = el.find(selector);
+        if (ret.length === 0) {
+          const msg = `No match for ${selector}`;
+          throw new Error(msg);
+        }
+        return ret;
+      };
+
+      // Find entry, throws if not exactly one.
+      const findOne = (el, selector) => {
+        const ret = findMany(el, selector);
+        if (ret.length !== 1) {
+          const msg = `Should have 1 match for ${selector}, got ${ret.length} (${ret.text()})`;
+          throw new Error(msg);
+        }
+        return ret;
+      };
+
+      /** Key-value dict, eg 'Total Cases' = 2345. */
+      const headingData = {};
+
+      /** Headings down lhs of the page. */
+      const sideHeadings = ['Total Tested', 'Total Negative Cases', 'Total Positive Cases', 'Total Fatalities'];
+      sideHeadings.forEach(h => {
+        const divs = findMany($.root(), `lego-table > div.table:contains('${h}')`);
+        // Gross hack.  The page contains both "Total Tested" and
+        // "Total Tested Prior Day", so the selector finds both of
+        // these values.  The full div text is actually a
+        // concatenation of all values, and the next value is 'No
+        // data', so checking for that, as it disambiguates "Total
+        // TestedNo Data" and "Total Tested Prior DayNo Data".
+        let div = divs.toArray().filter(d =>
+          $(d)
+            .text()
+            .includes(`${h}No data`)
+        );
+        assert.equal(div.length, 1, 'exactly 1 heading matches.');
+        div = $(div[0]);
+
+        const rows = findOne(div, 'div.tableBody > div.row');
+        const data = rows.text().replace(/,/, '');
+        headingData[h] = data;
+      });
+
+      /** Hospitalization data, transposed and added to headingData. */
+      const hospdiv = findOne($.root(), `lego-table > div.table:contains('Currently Hospitalized')`);
+      const ths = findMany(hospdiv, 'div.headerRow > div.headerCell > div.headerContentDiv > div.colName');
+      const headings = ths.toArray().map(th => $(th).text());
+      const expectedHospHeadings = [
+        'Currently Hospitalized',
+        'Currently in ICU',
+        'On Ventilator',
+        'Hospital Discharges'
+      ];
+      assert.deepEqual(expectedHospHeadings.sort(), headings.sort());
+      const hospRows = findOne(hospdiv, 'div.tableBody > div.row');
+      const rowcells = findMany(hospRows, 'div.cell');
+      const hospvalues = rowcells.toArray().map(c => $(c).text());
+      if (headings.length !== hospvalues.length)
+        throw new Error(`Different number of headings (${headings.join(',')}) than values (${hospvalues.join(',')})`);
+      for (let i = 0; i < headings.length; i++) {
+        headingData[headings[i]] = hospvalues[i];
+      }
+
+      /** City/Town data. */
+      const citydiv = findOne($.root(), "lego-table > div.table:contains('City/Town')");
+      const cityths = findMany(citydiv, 'div.headerRow > div.headerCell > div.headerContentDiv > div.colName');
+      const cityheadings = cityths.toArray().map(th => $(th).text());
+      const expectedCityHeadings = ['City/Town', 'Positive Cases'];
+      assert.deepEqual(expectedCityHeadings.sort(), cityheadings.sort());
+      const cityRaw = findMany(citydiv, 'div.tableBody > div.row')
+        .toArray()
+        .map(r => {
+          const rowcells = findMany($(r), 'div.cell');
+          const values = rowcells.toArray().map(c => $(c).text());
+          if (cityheadings.length !== values.length)
+            throw new Error(
+              `Different number of headings (${cityheadings.join(',')}) than values (${values.join(',')})`
+            );
+          return rowcells.toArray().map(c => $(c).text());
+        });
+
+      // console.log(headingData);
+      // console.log(cityRaw);
+
+      /** Get the headingData key value, throw if missing. */
+      function getRawHeaderValue(key) {
+        if (!headingData[key]) throw new Error(`Missing heading ${key}`);
+        return parseInt(headingData[key], 10);
+      }
+
+      /* TODO - verify the aggregate of this data. Copied from earlier entry. Should it be 'state'? */
+      const stateData = {
+        tested: getRawHeaderValue('Total Tested'),
+        cases: getRawHeaderValue('Total Positive Cases'),
+        deaths: getRawHeaderValue('Total Fatalities'),
+        hospitalized: getRawHeaderValue('Currently Hospitalized'),
+        discharged: getRawHeaderValue('Hospital Discharges'),
+        aggregate: 'county'
+      };
+
+      let regions = [];
+
+      regions.push(stateData);
+
+      const countyCases = {};
+      for (const county of this._counties) {
+        countyCases[county] = 0;
+      }
+
+      const numRows = cityRaw.length;
+      const cities = [];
+      for (let i = 0; i < numRows; i++) {
+        const city = cityRaw[i][0];
+        let cases = cityRaw[i][1];
+        if (cases === '<5') {
+          cases = 3; // pick something!
+        } else {
+          cases = parseInt(cases, 10);
+        }
+
+        // console.log('CITY: ' + city);
+        // console.log('CITY MAP LKP: ' + this._cities[city]);
+        const county = geography.addCounty(this._cities[city]);
+        countyCases[county] += cases;
+
+        cities.push({
+          county,
+          city,
+          cases
+        });
+      }
+
+      for (const county of this._counties) {
+        regions.push({
+          county,
+          cases: countyCases[county],
+          aggregate: 'city'
+        });
+      }
+
+      regions = geography.addEmptyRegions(regions, this._counties, 'county');
+      // no sum because we explicitly add it above
+
+      // Add in cities
+      regions = regions.concat(cities);
+
+      // console.log(regions);
 
       return regions;
     }


### PR DESCRIPTION
Fix broken scraper.

The code has a small amount of duplication that could be refactored, but it's more important to get it in, so we can get data.

I ran it locally, and from what I can tell, it's working.

extract of dist.json, matches numbers at https://ri-department-of-health-covid-19-data-rihealth.hub.arcgis.com/:

```
[
  {
    "state": "Rhode Island",
    "country": "United States",
    "sources": [
      {
        "url": "https://health.ri.gov/data/covid-19/",
        "name": "State of Rhode Island Department of Health"
      }
    ],
    "url": "https://health.ri.gov/data/covid-19/",
    "tested": 60165,
    "cases": 8247,
    "deaths": 251,
    "hospitalized": 269,
    "discharged": 55,
    "aggregate": "county",
    "rating": 0.45098039215686275,
    "coordinates": [
      -71.5075,
      41.584
    ],
    "tz": [
      "America/New_York"
    ],
    "featureId": "iso2:US-RI",
    "population": 1059361,
    "populationDensity": 379.1426847252138,
    "countryId": "iso1:US",
    "stateId": "iso2:US-RI",
    "name": "Rhode Island, United States",
    "level": "state"
  },
```