### PR TITLE
Fix US MS

### DIFF
--- a/src/shared/scrapers/US/MS/index.js
+++ b/src/shared/scrapers/US/MS/index.js
@@ -211,10 +211,13 @@ const scraper = {
       const $ = await fetch.page(this, this.url, 'default');
       const $table = $('#msdhTotalCovid-19Cases');
 
-      // Validate headings.
+      // Validate the headings we care about.
       const $ths = $table.find('thead > tr > td');
-      const headers = $ths.toArray().map(th => $(th).text());
-      const expectedHeaders = ['County', 'Total Cases', 'Total Deaths', 'LTCs with Outbreaks'];
+      const headers = $ths
+        .toArray()
+        .slice(0, 3)
+        .map(th => $(th).text());
+      const expectedHeaders = ['County', 'Total Cases', 'Total Deaths'];
       assert.equal(headers.join(','), expectedHeaders.join(','), 'expected table headers');
 
       const getCellTextArray = tr => {
@@ -229,7 +232,6 @@ const scraper = {
           .map(c => (c === '' ? '0' : c));
       };
       const getReportData = row => {
-        assert.equal(row.length, 4, 'cell count');
         let county = geography.addCounty(parse.string(row[0]));
         county = this._fixCountyTypos(county);
         return { county, cases: parse.number(row[1]), deaths: parse.number(row[2]) };

--- a/src/shared/scrapers/US/MS/index.js
+++ b/src/shared/scrapers/US/MS/index.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import * as transform from '../../../lib/transform.js';
@@ -156,16 +157,12 @@ const scraper = {
       // before the table of "total cases"
       const $td = $('td:contains("County")').last();
 
-      if (
-        $td.text() !== 'County' ||
-        $td.next().text() !== 'Cases' ||
-        $td
-          .next()
-          .next()
-          .text() !== 'Deaths'
-      ) {
-        throw new Error('Unexpected table headers');
-      }
+      const headers = [];
+      headers.push($td.text());
+      headers.push($td.next().text());
+      headers.push($td.next().next().text());
+      const expectedHeaders = [ 'County', 'Cases', 'Deaths' ];
+      assert.equal(headers.join(','), expectedHeaders.join(','), 'expected table headers');
 
       const $table = $td.closest('table');
       const $trs = $table.find('tbody > tr:not(:last-child)');


### PR DESCRIPTION
Addresses #874 , "US/MS scraper broken".

`yarn start --location US/MS` works successfully (and on prior dates too, had started failing as at `$ yarn start --location US/MS --date 2020-4-17` prior to this fix).  data.json extract:

```
  {
    "state": "Mississippi",
    "country": "United States",
    "sources": [
      {
        "url": "https://msdh.ms.gov/",
        "name": "Mississippi State Department of Health"
      }
    ],
    "url": "https://msdh.ms.gov/msdhsite/_static/14,0,420.html",
    "aggregate": "county",
    "cases": 6569,
    "deaths": 250,
    "rating": 0.39215686274509803,
    "coordinates": [
      -89.876,
      32.588
    ],
    "tz": [
      "America/Chicago"
    ],
    "featureId": "iso2:US-MS",
    "population": 2976149,
    "populationDensity": 24.0406877338177,
    "countryId": "iso1:US",
    "stateId": "iso2:US-MS",
    "name": "Mississippi, United States",
    "level": "state"
  }
```