### PR TITLE
back-port get-iso2-from-name

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "needle": "^2.3.3",
     "pdf2json": "^1.2.0",
     "puppeteer": "^2.1.1",
+    "slugify": "^1.4.0",
     "spacetime": "^6.4.3",
     "yargs": "^15.3.1"
   },

--- a/src/shared/utils/get-iso2-from-name.js
+++ b/src/shared/utils/get-iso2-from-name.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+const slugify = require('slugify');
+const iso2 = require('country-levels/iso2.json');
+
+const UNASSIGNED = '(unassigned)';
+
+const slugifyOptions = { lower: true };
+
+// Can be removed after https://github.com/simov/slugify/pull/76 is released.
+slugify.extend({ ō: 'o' });
+
+/**
+ * Find ISO2 code within a country.
+ * Guarantees non-ambiguous match (to avoid New York "City" or "State" problem).
+ * @param {object} options - Options.
+ * @param {string} options.country - The iso1 country code to match within (iso1:AU)
+ * @param {string} options.name - The name to look up ("Australian Capital Territory")
+ * @returns {string} - The iso2 ID ('iso2:AU-ACT').
+ */
+const getIso2FromName = ({ country, name }) => {
+  const iso2WithinIso1 = Object.values(iso2).filter(item => item.iso2.startsWith(country.replace('iso1:', '')));
+  if (name === UNASSIGNED) {
+    return name;
+  }
+  const slugName = slugify(name, slugifyOptions);
+  const foundItems = iso2WithinIso1.filter(canonicalItem =>
+    slugify(canonicalItem.name, slugifyOptions).includes(slugName)
+  );
+  assert.equal(
+    foundItems.length,
+    1,
+    `no single match found for ${name} in ${country}. Found ${iso2WithinIso1.map(item => item.name).join()}`
+  );
+  return foundItems[0].countrylevel_id;
+};
+
+module.exports = getIso2FromName;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6624,6 +6624,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+slugify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
+  integrity sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
## Summary

Back-port get-iso2-from-name and replace the prototype from JP with the fully defined function.
Aim is to make back/forward porting easier between the two repos.