### PR TITLE
Fix US/MO validation errors due to data using epoch for dates.

### DIFF
--- a/src/shared/scrapers/US/MO/index.js
+++ b/src/shared/scrapers/US/MO/index.js
@@ -285,10 +285,18 @@ const scraper = {
             counties[countyName].cases += parse.number(countyData.Cases || 0);
             counties[countyName].deaths += parse.number(countyData.Deaths || 0);
           } else {
+            // On 2020-4-28, MO switched from recording dates as UTC
+            // (eg, "2020-04-27T18:13:20.273Z") to epoch (eg,
+            // 1585082918049, an _integer_ = milliseconds from Jan 1,
+            // 1970).  The Date constructor handles both of these.
+            let d = countyData.EditDate;
+            // Check if using epoch.
+            if (d.match(/^\d+$/)) d = parseInt(d, 10);
+            const editDate = new Date(d);
             counties[countyName] = {
               cases: parse.number(countyData.Cases || 0),
               deaths: parse.number(countyData.Deaths || 0),
-              publishedDate: countyData.EditDate
+              publishedDate: editDate.toISOString()
             };
           }
         }


### PR DESCRIPTION
MO switched to epoch for edit date in their data sources:

`$ cat coronadatascraper-cache/2020-4-27/9cd650122f1e65a5a95a77187448db0c.csv` =
`116,Kansas City, ... 2020-04-27T18:13:20.273Z,mophep,,,,,,,,,,,`

For the next date (2020-4-28) the same url:

`116,Kansas City, ... 1588100245140,mophep,,,,,,,,,,,`

`1588100245140` is epoch.  This is giving us a ton of validation errors:

```
$ yarn start --location US/MO/index.js -d 2020-04-28
...
Kansas City, Missouri, United States .publishedDate should match format "date-time"
...
```

With this fix, all is well.

Closes https://github.com/covidatlas/coronadatascraper/issues/936