### PR TITLE
Generate reports with cds and li

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ public/*.js.map
 coronavirus-data-sources/
 dist/
 dist-raw/
+dist-raw-li/
 node_modules
 public/*.json
 sam.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ public/*.js
 public/*.js.map
 coronavirus-data-sources/
 dist/
+dist-raw/
 node_modules
 public/*.json
 sam.json

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint": "eslint .",
     "options": "node -r esm src/shared/cli/cli-args.js -h",
     "start": "node src/shared/cli/index.js",
+    "raw:scrape": "node src/shared/cli/rawscrape.js",
+    "raw:report": "node src/shared/cli/rawreport.js",
     "qa": "pta ./src/qa/*.qa.js -r log | node src/qa/utils/qa-reporter.js",
     "test": "tape tests/**/*-test.js | tap-spec",
     "test:unit": "tape tests/unit/**/*-test.js | tap-spec",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "start": "node src/shared/cli/index.js",
     "raw:scrape": "node src/shared/cli/rawscrape.js",
     "raw:report": "node src/shared/cli/rawreport.js",
+    "raw:reportcombined": "node src/shared/cli/rawcombinedreport.js",
     "qa": "pta ./src/qa/*.qa.js -r log | node src/qa/utils/qa-reporter.js",
     "test": "tape tests/**/*-test.js | tap-spec",
     "test:unit": "tape tests/unit/**/*-test.js | tap-spec",

--- a/scripts/li-and-cds-report-gen.sh
+++ b/scripts/li-and-cds-report-gen.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Run this script from project root.
+
+# Regression/generation of reports
+#
+# 1. Generate reports to zz-master using 'yarn raw:*' methods
+# 2. Generate reports to dist using 'yarn start'
+# 3. Export raw files from li end gen reports to zz-combined using 'yarn raw:combined'
+# 4. Compare them.
+#
+# Assumptions:
+#
+# * li is in a sibling directory to cds
+# * li is checked out to a branch that has tools/gen-raw-files and associated changes
+
+lifilt=''
+cdsfilt=''
+
+if [ "$1" == "sf" ]; then
+    lifilt='-s us-ca-san-francisco-county'
+    cdsfilt='--location US/CA/san-francisco-county.js'
+fi
+
+if [ "$1" == "ut" ]; then
+    lifilt='-s us-ut'
+    cdsfilt='--location US/UT'
+fi
+
+# Delete all so things aren't polluted.
+rm -rf dist dist-raw dist-raw-li zz-combined zz-master
+
+# 1. Run master with raw files, generating to zz-master
+yarn raw:scrape $cdsfilt
+yarn raw:report --writeTo zz-master
+
+# 2. Run regular master, generating reports to dist
+yarn start --writeTo $cdsfilt
+
+# 3. Export files from Li, and run the 'combined' report to zz-combined.
+pushd ../li
+node tools/gen-raw-files.js -c -o ../coronadatascraper/dist-raw-li $lifilt
+popd
+yarn raw:reportcombined --writeTo zz-combined
+
+# 4. COMPARE!
+echo ==================================================
+echo 'DIST to ZZ-MASTER'
+node tools/compare-report-dirs.js --left dist --right zz-master
+echo ==================================================
+echo 'DIST to ZZ-COMBINED'
+node tools/compare-report-dirs.js --left dist --right zz-combined
+echo ==================================================

--- a/src/events/crawler/get-sources/index.js
+++ b/src/events/crawler/get-sources/index.js
@@ -1,10 +1,7 @@
 import loadSources from './load-sources.js';
-import validateSources from './validate-sources.js';
 
 async function fetchSources(options) {
-  const sources = await loadSources(options);
-  const errors = validateSources(sources);
-  return { sources, validationErrors: errors };
+  return await loadSources(options);
 }
 
 export default fetchSources;

--- a/src/events/crawler/get-sources/index.js
+++ b/src/events/crawler/get-sources/index.js
@@ -1,7 +1,7 @@
 import loadSources from './load-sources.js';
 
 async function fetchSources(options) {
-  return await loadSources(options);
+  return loadSources(options);
 }
 
 export default fetchSources;

--- a/src/events/crawler/get-sources/index.js
+++ b/src/events/crawler/get-sources/index.js
@@ -1,6 +1,10 @@
 import loadSources from './load-sources.js';
 import validateSources from './validate-sources.js';
 
-const fetchSources = async args => loadSources(args).then(validateSources);
+async function fetchSources(options) {
+  const sources = await loadSources(options);
+  const errors = validateSources(sources);
+  return { sources, validationErrors: errors };
+}
 
 export default fetchSources;

--- a/src/events/crawler/get-sources/load-sources.js
+++ b/src/events/crawler/get-sources/load-sources.js
@@ -20,7 +20,7 @@ function includeLocation(location, opts) {
   return true;
 }
 
-export default async args => {
+export default async function loadSources(options) {
   log(`⏳ Fetching scrapers...`);
   const scrapers = join(__dirname, '..', '..', '..', 'shared', 'scrapers', '**', '*.js');
   let filePaths = await fastGlob([scrapers]);
@@ -42,7 +42,7 @@ export default async args => {
     return 0;
   };
 
-  const filteredSources = sources.filter(m => includeLocation(m, args.options)).sort(sortSources);
+  const filteredSources = sources.filter(m => includeLocation(m, options)).sort(sortSources);
 
   if (filteredSources.length === 0) {
     log(`location filter returned 0 scrapers.  Please check docs/getting_started.`);
@@ -52,5 +52,5 @@ export default async args => {
     log(`✅ Fetched ${sources.length} scrapers.`);
   }
 
-  return { ...args, sources: filteredSources };
-};
+  return filteredSources;
+}

--- a/src/events/crawler/get-sources/validate-sources.js
+++ b/src/events/crawler/get-sources/validate-sources.js
@@ -2,9 +2,7 @@ import * as schema from '../../../shared/lib/schema.js';
 import log from '../../../shared/lib/log.js';
 import reporter from '../../../shared/lib/error-reporter.js';
 
-const validateSources = async args => {
-  const { sources, report } = args;
-
+const validateSources = sources => {
   const errors = [];
   for (const source of sources) {
     const schemaErrors = schema.schemaHasErrors(source, schema.schemas.scraperSchema, {});
@@ -24,12 +22,7 @@ const validateSources = async args => {
     log(`✅ All scrapers are valid!`);
   }
 
-  report.sources = {
-    numSources: sources.length,
-    errors
-  };
-
-  return args;
+  return errors;
 };
 
 export default validateSources;

--- a/src/events/crawler/get-sources/validate-sources.js
+++ b/src/events/crawler/get-sources/validate-sources.js
@@ -24,5 +24,4 @@ export default function validateSources(sources, report) {
 
   report.numSources = sources.length;
   report.errors = errors;
-};
-
+}

--- a/src/events/crawler/get-sources/validate-sources.js
+++ b/src/events/crawler/get-sources/validate-sources.js
@@ -2,7 +2,7 @@ import * as schema from '../../../shared/lib/schema.js';
 import log from '../../../shared/lib/log.js';
 import reporter from '../../../shared/lib/error-reporter.js';
 
-const validateSources = sources => {
+export default function validateSources(sources, report) {
   const errors = [];
   for (const source of sources) {
     const schemaErrors = schema.schemaHasErrors(source, schema.schemas.scraperSchema, {});
@@ -22,7 +22,7 @@ const validateSources = sources => {
     log(`✅ All scrapers are valid!`);
   }
 
-  return errors;
+  report.numSources = sources.length;
+  report.errors = errors;
 };
 
-export default validateSources;

--- a/src/events/crawler/scrape-data/index.js
+++ b/src/events/crawler/scrape-data/index.js
@@ -2,10 +2,10 @@ import runScrapers from './run-scraper.js';
 import normalizeLocations from './normalize-locations.js';
 
 export default async function scrapeData(sources, report) {
-  let { locations, scraperErrors } = await runScrapers(sources);
-  locations = await normalizeLocations(locations);
+  const { locations, scraperErrors } = await runScrapers(sources);
+  const normalizedLocations = await normalizeLocations(locations);
 
   report.numErrors = scraperErrors.length;
   report.errors = scraperErrors;
-  return locations;
+  return normalizedLocations;
 }

--- a/src/events/crawler/scrape-data/index.js
+++ b/src/events/crawler/scrape-data/index.js
@@ -1,8 +1,11 @@
 import runScrapers from './run-scraper.js';
 import normalizeLocations from './normalize-locations.js';
 
-export default async function scrapeData(sources) {
+export default async function scrapeData(sources, report) {
   let { locations, scraperErrors } = await runScrapers(sources);
   locations = await normalizeLocations(locations);
-  return { locations, scraperErrors }
+
+  report.numErrors = scraperErrors.length;
+  report.errors = scraperErrors;
+  return locations;
 }

--- a/src/events/crawler/scrape-data/index.js
+++ b/src/events/crawler/scrape-data/index.js
@@ -1,6 +1,8 @@
 import runScrapers from './run-scraper.js';
 import normalizeLocations from './normalize-locations.js';
 
-const scrapeData = async args => runScrapers(args).then(normalizeLocations);
-
-export default scrapeData;
+export default async function scrapeData(sources) {
+  let { locations, scraperErrors } = await runScrapers(sources);
+  locations = await normalizeLocations(locations);
+  return { locations, scraperErrors }
+}

--- a/src/events/crawler/scrape-data/normalize-locations.js
+++ b/src/events/crawler/scrape-data/normalize-locations.js
@@ -101,5 +101,4 @@ export default function normalizeLocations(locations) {
   }
 
   return filteredLocations;
-};
-
+}

--- a/src/events/crawler/scrape-data/normalize-locations.js
+++ b/src/events/crawler/scrape-data/normalize-locations.js
@@ -18,10 +18,9 @@ function findCountryLevelID(location) {
   return null;
 }
 
-const normalizeLocations = args => {
+export default function normalizeLocations(locations) {
   log('⏳ Normalizing locations...');
 
-  const { locations } = args;
   const filteredLocations = [];
 
   // Normalize data
@@ -101,7 +100,6 @@ const normalizeLocations = args => {
     filteredLocations.push(location);
   }
 
-  return { ...args, locations: filteredLocations };
+  return filteredLocations;
 };
 
-export default normalizeLocations;

--- a/src/events/crawler/scrape-data/run-scraper.js
+++ b/src/events/crawler/scrape-data/run-scraper.js
@@ -121,9 +121,7 @@ export async function runScraper(location) {
   return scraperOutput;
 }
 
-const runScrapers = async args => {
-  const { sources } = args;
-
+export default async function runScrapers(sources) {
   const locations = [];
   const errors = [];
   for (const location of sources) {
@@ -147,7 +145,5 @@ const runScrapers = async args => {
     }
   }
 
-  return { ...args, locations, scraperErrors: errors };
+  return { locations, scraperErrors: errors };
 };
-
-export default runScrapers;

--- a/src/events/crawler/scrape-data/run-scraper.js
+++ b/src/events/crawler/scrape-data/run-scraper.js
@@ -146,4 +146,4 @@ export default async function runScrapers(sources) {
   }
 
   return { locations, scraperErrors: errors };
-};
+}

--- a/src/events/processor/clean-locations/index.js
+++ b/src/events/processor/clean-locations/index.js
@@ -29,4 +29,4 @@ export default function cleanLocations(locations, report) {
   }
 
   report.errors = errors;
-};
+}

--- a/src/events/processor/clean-locations/index.js
+++ b/src/events/processor/clean-locations/index.js
@@ -28,7 +28,5 @@ export default function cleanLocations(locations, report) {
     log(`✅ All locations are valid!`);
   }
 
-  report.validate = {
-    errors
-  };
+  report.errors = errors;
 };

--- a/src/events/processor/clean-locations/index.js
+++ b/src/events/processor/clean-locations/index.js
@@ -6,10 +6,8 @@ import reporter from '../../../shared/lib/error-reporter.js';
 /*
   Clean the passed data
 */
-const cleanLocations = args => {
+export default function cleanLocations(locations, report) {
   log(`⏳ Validating and cleaning locations...`);
-
-  const { locations, report } = args;
 
   const errors = [];
   for (const location of locations) {
@@ -33,8 +31,4 @@ const cleanLocations = args => {
   report.validate = {
     errors
   };
-
-  return args;
 };
-
-export default cleanLocations;

--- a/src/events/processor/dedupe-locations/index.js
+++ b/src/events/processor/dedupe-locations/index.js
@@ -174,4 +174,4 @@ export default function dedupeLocations(locations, report) {
 
   report.numDuplicates = deDuped;
   report.crosscheckReports = crosscheckReports;
-};
+}

--- a/src/events/processor/dedupe-locations/index.js
+++ b/src/events/processor/dedupe-locations/index.js
@@ -89,10 +89,8 @@ function addCrosscheckReport(crosscheckReports, locationName, crosscheckResult, 
   report.dropped.push(report.sources.length - 1);
 }
 
-const dedupeLocations = args => {
+export default function dedupeLocations(locations) {
   log(`⏳ De-duping locations...`);
-
-  const { locations } = args;
 
   const crosscheckReports = {};
   const seenLocations = {};
@@ -174,7 +172,6 @@ const dedupeLocations = args => {
 
   log('✅ De-duped %d locations and found %d crosscheck failures! ', deDuped, crossCheckFailures);
 
-  return { ...args, deDuped, crosscheckReports };
+  return { deDuped, crosscheckReports };
 };
 
-export default dedupeLocations;

--- a/src/events/processor/dedupe-locations/index.js
+++ b/src/events/processor/dedupe-locations/index.js
@@ -89,7 +89,7 @@ function addCrosscheckReport(crosscheckReports, locationName, crosscheckResult, 
   report.dropped.push(report.sources.length - 1);
 }
 
-export default function dedupeLocations(locations) {
+export default function dedupeLocations(locations, report) {
   log(`⏳ De-duping locations...`);
 
   const crosscheckReports = {};
@@ -172,6 +172,6 @@ export default function dedupeLocations(locations) {
 
   log('✅ De-duped %d locations and found %d crosscheck failures! ', deDuped, crossCheckFailures);
 
-  return { deDuped, crosscheckReports };
+  report.numDuplicates = deDuped;
+  report.crosscheckReports = crosscheckReports;
 };
-

--- a/src/events/processor/find-features/index.js
+++ b/src/events/processor/find-features/index.js
@@ -117,7 +117,7 @@ function locationPropertyMatchesFeature(locationItem, feature) {
   );
 }
 
-export default function generateFeatures (locations, report) {
+export default function generateFeatures(locations, report) {
   const featureCollection = {
     type: 'FeatureCollection',
     features: []
@@ -395,5 +395,4 @@ export default function generateFeatures (locations, report) {
 
     resolve(featureCollection);
   });
-};
-
+}

--- a/src/events/processor/find-features/index.js
+++ b/src/events/processor/find-features/index.js
@@ -117,7 +117,7 @@ function locationPropertyMatchesFeature(locationItem, feature) {
   );
 }
 
-const generateFeatures = ({ locations, report, options, sourceRatings }) => {
+export default function generateFeatures (locations) {
   const featureCollection = {
     type: 'FeatureCollection',
     features: []
@@ -390,13 +390,12 @@ const generateFeatures = ({ locations, report, options, sourceRatings }) => {
       featureCollection.features.length
     );
 
-    report.findFeatures = {
+    const reportResult = {
       numFeaturesFound: foundCount,
       missingFeatures: errors
     };
 
-    resolve({ locations, featureCollection, report, options, sourceRatings });
+    resolve({ locations, featureCollection, reportResult });
   });
 };
 
-export default generateFeatures;

--- a/src/events/processor/find-features/index.js
+++ b/src/events/processor/find-features/index.js
@@ -395,7 +395,7 @@ export default function generateFeatures (locations) {
       missingFeatures: errors
     };
 
-    resolve({ locations, featureCollection, reportResult });
+    resolve({ featureCollection, reportResult });
   });
 };
 

--- a/src/events/processor/find-features/index.js
+++ b/src/events/processor/find-features/index.js
@@ -117,7 +117,7 @@ function locationPropertyMatchesFeature(locationItem, feature) {
   );
 }
 
-export default function generateFeatures (locations) {
+export default function generateFeatures (locations, report) {
   const featureCollection = {
     type: 'FeatureCollection',
     features: []
@@ -390,12 +390,10 @@ export default function generateFeatures (locations) {
       featureCollection.features.length
     );
 
-    const reportResult = {
-      numFeaturesFound: foundCount,
-      missingFeatures: errors
-    };
+    report.numFeaturesFound = foundCount;
+    report.missingFeatures = errors;
 
-    resolve({ featureCollection, reportResult });
+    resolve(featureCollection);
   });
 };
 

--- a/src/events/processor/find-populations/index.js
+++ b/src/events/processor/find-populations/index.js
@@ -175,4 +175,4 @@ export default async function generatePopulations(locations, featureCollection, 
 
   report.numLocationsWithPopulation = populationFound;
   report.missingPopulations = errors;
-};
+}

--- a/src/events/processor/find-populations/index.js
+++ b/src/events/processor/find-populations/index.js
@@ -173,10 +173,10 @@ export default async function generatePopulations(locations, featureCollection) 
   }
   log('✅ Found population data for %d out of %d locations', populationFound, Object.keys(locations).length);
 
-  const result = {
+  const report = {
     numLocationsWithPopulation: populationFound,
     missingPopulations: errors
   };
 
-  return { locations, result };
+  return report;
 };

--- a/src/events/processor/find-populations/index.js
+++ b/src/events/processor/find-populations/index.js
@@ -67,7 +67,7 @@ async function readPopulationData(featureCollection) {
   return populations;
 }
 
-const generatePopulations = async ({ locations, featureCollection, report, options, sourceRatings }) => {
+export default async function generatePopulations(locations, featureCollection) {
   log('⏳ Getting population data...');
 
   const populations = await readPopulationData(featureCollection);
@@ -173,12 +173,10 @@ const generatePopulations = async ({ locations, featureCollection, report, optio
   }
   log('✅ Found population data for %d out of %d locations', populationFound, Object.keys(locations).length);
 
-  report.findPopulation = {
+  const result = {
     numLocationsWithPopulation: populationFound,
     missingPopulations: errors
   };
 
-  return { locations, featureCollection, report, options, sourceRatings };
+  return { locations, result };
 };
-
-export default generatePopulations;

--- a/src/events/processor/find-populations/index.js
+++ b/src/events/processor/find-populations/index.js
@@ -67,7 +67,7 @@ async function readPopulationData(featureCollection) {
   return populations;
 }
 
-export default async function generatePopulations(locations, featureCollection) {
+export default async function generatePopulations(locations, featureCollection, report) {
   log('⏳ Getting population data...');
 
   const populations = await readPopulationData(featureCollection);
@@ -173,10 +173,6 @@ export default async function generatePopulations(locations, featureCollection) 
   }
   log('✅ Found population data for %d out of %d locations', populationFound, Object.keys(locations).length);
 
-  const report = {
-    numLocationsWithPopulation: populationFound,
-    missingPopulations: errors
-  };
-
-  return report;
+  report.numLocationsWithPopulation = populationFound;
+  report.missingPopulations = errors;
 };

--- a/src/events/processor/rate-sources/calculate-ratings.js
+++ b/src/events/processor/rate-sources/calculate-ratings.js
@@ -86,10 +86,8 @@ const rateLocation = location => {
   return rating / bestScore;
 };
 
-const calculateRatings = async args => {
+export default async function calculateRatings(sources, locations) {
   log(`⏳ Calculating ratings...`);
-
-  const { sources, locations } = args;
 
   const scoreBySource = {};
   sources.forEach(source => {
@@ -107,7 +105,5 @@ const calculateRatings = async args => {
 
   const sourceRatings = sources.filter(source => source.rating !== undefined).sort((a, b) => b.rating - a.rating);
 
-  return { ...args, sourceRatings };
-};
-
-export default calculateRatings;
+  return sourceRatings;
+}

--- a/src/events/processor/rate-sources/index.js
+++ b/src/events/processor/rate-sources/index.js
@@ -1,6 +1,7 @@
 import calculateRatings from './calculate-ratings.js';
 import validateRatings from './validate-ratings.js';
 
-const rateSources = async args => calculateRatings(args).then(validateRatings);
-
-export default rateSources;
+export default async function rateSources(sources, locations) {
+  const ratings = await calculateRatings(sources, locations);
+  return validateRatings(ratings);
+}

--- a/src/events/processor/rate-sources/validate-ratings.js
+++ b/src/events/processor/rate-sources/validate-ratings.js
@@ -1,9 +1,7 @@
 import * as schema from '../../../shared/lib/schema.js';
 import log from '../../../shared/lib/log.js';
 
-const validateRatings = async args => {
-  const { sourceRatings } = args;
-
+export default function validateRatings(sourceRatings) {
   for (const rating of sourceRatings) {
     const schemaErrors = schema.schemaHasErrors(rating, schema.schemas.ratingSchema, { removeAdditional: true });
     if (schemaErrors) {
@@ -15,8 +13,5 @@ const validateRatings = async args => {
   }
 
   log('✅ Assigned ratings for %d sources', sourceRatings.length);
-
-  return args;
-};
-
-export default validateRatings;
+  return sourceRatings;
+}

--- a/src/events/processor/read-li-raw-data/index.js
+++ b/src/events/processor/read-li-raw-data/index.js
@@ -1,0 +1,43 @@
+import path from 'path';
+import fs from 'fs';
+
+/** Read generated raw files from dist-raw. */
+const rawDirectory = path.join(__dirname, '..', '..', '..', '..', 'dist-raw-li');
+
+/** Get filenames. */
+function rawFilenames(options) {
+  let suffix = '';
+  if (options.outputSuffix !== undefined) {
+    suffix = options.outputSuffix;
+  } else if (process.env.SCRAPE_DATE) {
+    suffix = `-${process.env.SCRAPE_DATE}`;
+  }
+
+  return {
+    // The sources scraped.
+    sourcesPath: path.join(rawDirectory, `raw-li-sources${suffix}.json`),
+
+    // The full raw data of all scraped locations.
+    locationsPath: path.join(rawDirectory, `raw-li-locations${suffix}.json`)
+  };
+}
+
+/** Reconstitute data from old raw JSON files.  Bump the priority of li sources way up! */
+export default function loadRawPriorityAdjusted(options) {
+  function readJson(f) {
+    if (!f) throw new Error('null file path');
+    if (!fs.existsSync(f)) throw new Error(`Missing raw file ${f}`);
+    const rawdata = fs.readFileSync(f);
+    return JSON.parse(rawdata);
+  }
+
+  const raws = rawFilenames(options);
+  const liSources = readJson(raws.sourcesPath);
+  const liLocations = readJson(raws.locationsPath);
+
+  liLocations.forEach(loc => {
+    loc.priority = 100 + (loc.priority || 0);
+  });
+
+  return { liSources, liLocations };
+}

--- a/src/events/processor/read-li-raw-data/index.js
+++ b/src/events/processor/read-li-raw-data/index.js
@@ -28,6 +28,7 @@ export default function loadRawPriorityAdjusted(options) {
     if (!f) throw new Error('null file path');
     if (!fs.existsSync(f)) throw new Error(`Missing raw file ${f}`);
     const rawdata = fs.readFileSync(f);
+    console.log(`Loading ${f.replace(rawDirectory, '')}`);
     return JSON.parse(rawdata);
   }
 

--- a/src/events/processor/report/index.js
+++ b/src/events/processor/report/index.js
@@ -1,7 +1,6 @@
 import log from '../../../shared/lib/log.js';
 
-const reportScraping = args => {
-  const { locations, scraperErrors, deDuped, crosscheckReports, report } = args;
+export default function reportScraping(locations, scraperErrors, deDuped, crosscheckReports, report) {
 
   const locationCounts = {
     cities: 0,
@@ -56,8 +55,4 @@ const reportScraping = args => {
     crosscheckReports,
     errors: scraperErrors
   };
-
-  return args;
 };
-
-export default reportScraping;

--- a/src/events/processor/report/index.js
+++ b/src/events/processor/report/index.js
@@ -1,7 +1,6 @@
 import log from '../../../shared/lib/log.js';
 
 export default function reportScraping(locations, report) {
-
   const locationCounts = {
     cities: 0,
     states: 0,
@@ -50,4 +49,4 @@ export default function reportScraping(locations, report) {
   report.numStates = locationCounts.states;
   report.numCounties = locationCounts.counties;
   report.numCities = locationCounts.cities;
-};
+}

--- a/src/events/processor/report/index.js
+++ b/src/events/processor/report/index.js
@@ -1,6 +1,6 @@
 import log from '../../../shared/lib/log.js';
 
-export default function reportScraping(locations, scraperErrors, deDuped, crosscheckReports, report) {
+export default function reportScraping(locations, report) {
 
   const locationCounts = {
     cities: 0,
@@ -41,18 +41,13 @@ export default function reportScraping(locations, scraperErrors, deDuped, crossc
   for (const [name, count] of Object.entries(caseCounts)) {
     log('   - %d %s', count, name);
   }
-  if (scraperErrors.length) {
-    log('❌ %d error%s', scraperErrors.length, scraperErrors.length === 1 ? '' : 's');
+  const n = report.errors.length;
+  if (n) {
+    log('❌ %d error%s', n, n === 1 ? '' : 's');
   }
 
-  report.scrape = {
-    numCountries: locationCounts.countries,
-    numStates: locationCounts.states,
-    numCounties: locationCounts.counties,
-    numCities: locationCounts.cities,
-    numDuplicates: deDuped,
-    numErrors: scraperErrors.length,
-    crosscheckReports,
-    errors: scraperErrors
-  };
+  report.numCountries = locationCounts.countries;
+  report.numStates = locationCounts.states;
+  report.numCounties = locationCounts.counties;
+  report.numCities = locationCounts.cities;
 };

--- a/src/events/processor/transform-ids/index.js
+++ b/src/events/processor/transform-ids/index.js
@@ -16,7 +16,7 @@ function compare(a, b) {
   return a.localeCompare(b);
 }
 
-const transformIds = async ({ locations, featureCollection, report, options, sourceRatings }) => {
+export default async function transformIds(locations, report, sourceRatings) {
   log('⏳ Transforming IDs...');
 
   let idsFound = 0;
@@ -66,8 +66,4 @@ const transformIds = async ({ locations, featureCollection, report, options, sou
   report.transformIds = {
     idsResolved: idsFound
   };
-
-  return { locations, featureCollection, report, options, sourceRatings };
 };
-
-export default transformIds;

--- a/src/events/processor/transform-ids/index.js
+++ b/src/events/processor/transform-ids/index.js
@@ -64,4 +64,4 @@ export default async function transformIds(locations, sourceRatings, reportScrap
   });
 
   reportTransformIds.idsResolved = idsFound;
-};
+}

--- a/src/events/processor/transform-ids/index.js
+++ b/src/events/processor/transform-ids/index.js
@@ -16,7 +16,7 @@ function compare(a, b) {
   return a.localeCompare(b);
 }
 
-export default async function transformIds(locations, report, sourceRatings) {
+export default async function transformIds(locations, sourceRatings, reportScrape, reportTransformIds) {
   log('⏳ Transforming IDs...');
 
   let idsFound = 0;
@@ -48,13 +48,13 @@ export default async function transformIds(locations, report, sourceRatings) {
   // Transform crosscheck reports
   const crosscheckReports = [];
 
-  for (const [, crosscheckReport] of Object.entries(report.scrape.crosscheckReports)) {
+  for (const [, crosscheckReport] of Object.entries(reportScrape.crosscheckReports)) {
     // Transform no matter what
     await countryLevels.transformLocationIds(crosscheckReport.location);
     crosscheckReports.push(crosscheckReport);
   }
 
-  report.scrape.crosscheckReports = crosscheckReports.sort((a, b) => {
+  reportScrape.crosscheckReports = crosscheckReports.sort((a, b) => {
     return (
       compare(a.location.city, b.location.city) ||
       compare(a.location.county, b.location.county) ||
@@ -63,7 +63,5 @@ export default async function transformIds(locations, report, sourceRatings) {
     );
   });
 
-  report.transformIds = {
-    idsResolved: idsFound
-  };
+  reportTransformIds.idsResolved = idsFound;
 };

--- a/src/events/processor/write-data/dump-regression-raw.js
+++ b/src/events/processor/write-data/dump-regression-raw.js
@@ -1,20 +1,20 @@
 import path from 'path';
 import * as fs from '../../../shared/lib/fs.js';
 
-const writeRawRegression = async args => {
-  if (!args.options.dumpRaw) return args;
+export default async function writeRawRegression(locations, options) {
+  if (!options.dumpRaw) return;
 
   let suffix = '';
-  if (args.options.outputSuffix !== undefined) {
-    suffix = args.options.outputSuffix;
+  if (options.outputSuffix !== undefined) {
+    suffix = options.outputSuffix;
   } else if (process.env.SCRAPE_DATE) {
     suffix = `-${process.env.SCRAPE_DATE}`;
   }
 
-  const d = args.options.writeTo;
+  const d = options.writeTo;
   await fs.ensureDir(d);
 
-  const data = args.locations;
+  const data = locations;
   const keyCollector = data.reduce((hsh, val) => {
     return { ...hsh, ...val };
   }, {});
@@ -65,8 +65,4 @@ const writeRawRegression = async args => {
   await fs.writeJSON(path.join(d, `raw${suffix}.json`), output, { space: 2 });
 
   await fs.writeJSON(path.join(d, `raw-full${suffix}.json`), data, { space: 2 });
-
-  return args;
-};
-
-export default writeRawRegression;
+}

--- a/src/events/processor/write-data/dump-regression-raw.js
+++ b/src/events/processor/write-data/dump-regression-raw.js
@@ -64,6 +64,8 @@ const writeRawRegression = async args => {
   });
   await fs.writeJSON(path.join(d, `raw${suffix}.json`), output, { space: 2 });
 
+  await fs.writeJSON(path.join(d, `raw-full${suffix}.json`), data, { space: 2 });
+
   return args;
 };
 

--- a/src/events/processor/write-data/index.js
+++ b/src/events/processor/write-data/index.js
@@ -29,4 +29,4 @@ export default async function writeData(locations, featureCollection, ratings, r
   await fs.writeCSV(join(d, 'reports', 'crawler-report.csv'), reporter.getCSV());
 
   return { locations, featureCollection, report, options };
-};
+}

--- a/src/events/processor/write-data/index.js
+++ b/src/events/processor/write-data/index.js
@@ -3,7 +3,7 @@ import * as fs from '../../../shared/lib/fs.js';
 import * as stringify from './stringify.js';
 import reporter from '../../../shared/lib/error-reporter.js';
 
-const writeData = async ({ locations, featureCollection, report, options, sourceRatings }) => {
+export default async function writeData(locations, featureCollection, ratings, report, options) {
   let suffix = '';
   if (options.outputSuffix !== undefined) {
     suffix = options.outputSuffix;
@@ -24,11 +24,9 @@ const writeData = async ({ locations, featureCollection, report, options, source
 
   await fs.writeJSON(join(d, 'report.json'), report, { space: 2 });
 
-  await fs.writeJSON(join(d, 'ratings.json'), sourceRatings, { space: 2 });
+  await fs.writeJSON(join(d, 'ratings.json'), ratings, { space: 2 });
 
   await fs.writeCSV(join(d, 'reports', 'crawler-report.csv'), reporter.getCSV());
 
   return { locations, featureCollection, report, options };
 };
-
-export default writeData;

--- a/src/events/processor/write-data/write-raw.js
+++ b/src/events/processor/write-data/write-raw.js
@@ -3,6 +3,9 @@ import fs from 'fs';
 
 import reporter from '../../../shared/lib/error-reporter.js';
 
+/** Save and read generated raw files from dist-raw. */
+const rawDirectory = path.join(__dirname, '..', '..', '..', '..', 'dist-raw');
+
 /** Get filenames. */
 function rawFilenames(options) {
   let suffix = '';
@@ -12,26 +15,24 @@ function rawFilenames(options) {
     suffix = `-${process.env.SCRAPE_DATE}`;
   }
 
-  const d = options.writeTo;
-
   return {
     // All keys present in the raw-full file (for debugging/interest)
-    keysPath: path.join(d, `raw-keys${suffix}.json`),
+    keysPath: path.join(rawDirectory, `raw-keys${suffix}.json`),
 
     // The sources scraped.
-    sourcesPath: path.join(d, `raw-sources${suffix}.json`),
+    sourcesPath: path.join(rawDirectory, `raw-sources${suffix}.json`),
 
     // The full raw data of all scraped locations.
-    locationsPath: path.join(d, `raw-locations${suffix}.json`),
+    locationsPath: path.join(rawDirectory, `raw-locations${suffix}.json`),
 
     // the error-reporter errors.
-    errorReporterErrorsPath: path.join(d, `raw-error-reporter${suffix}.json`),
+    errorReporterErrorsPath: path.join(rawDirectory, `raw-error-reporter${suffix}.json`),
 
     // A brief version raw-full, pulling out interesting fields.
-    locationsBriefPath: path.join(d, `raw-locations-brief${suffix}.json`),
+    locationsBriefPath: path.join(rawDirectory, `raw-locations-brief${suffix}.json`),
 
     // The "report.json" accumulated during all report generation.
-    reportPath: path.join(d, `raw-report${suffix}.json`)
+    reportPath: path.join(rawDirectory, `raw-report${suffix}.json`)
   };
 }
 
@@ -47,7 +48,7 @@ export async function writeRaw(sources, locations, report, options) {
     reportPath
   } = rawFilenames(options);
 
-  if (!fs.existsSync(options.writeTo)) fs.mkdirSync(options.writeTo);
+  if (!fs.existsSync(rawDirectory)) fs.mkdirSync(rawDirectory);
 
   function writeJson(f, data) {
     fs.writeFileSync(f, JSON.stringify(data, null, 2));

--- a/src/events/processor/write-data/write-raw.js
+++ b/src/events/processor/write-data/write-raw.js
@@ -1,9 +1,8 @@
 import path from 'path';
-import * as fs from '../../../shared/lib/fs.js';
+import fs from 'fs';
 
-export default async function writeRaw(locations, report, options) {
-  if (!options.dumpRaw) return;
-
+/** Get filenames. */
+function rawFilenames(options) {
   let suffix = '';
   if (options.outputSuffix !== undefined) {
     suffix = options.outputSuffix;
@@ -12,13 +11,40 @@ export default async function writeRaw(locations, report, options) {
   }
 
   const d = options.writeTo;
-  await fs.ensureDir(d);
 
-  const data = locations;
-  const keyCollector = data.reduce((hsh, val) => {
+  return {
+    // All keys present in the raw-full file (for debugging/interest)
+    keysPath: path.join(d, `raw-keys${suffix}.json`),
+
+    // The full raw data of all scraped locations.
+    locationsPath: path.join(d, `raw-locations${suffix}.json`),
+
+    // A brief version raw-full, pulling out interesting fields.
+    locationsBriefPath: path.join(d, `raw-locations-brief${suffix}.json`),
+
+    // The "report.json" accumulated during all report generation.
+    reportPath: path.join(d, `raw-report${suffix}.json`)
+  };
+}
+
+export async function writeRaw(locations, report, options) {
+  if (!options.dumpRaw) return;
+
+  const { keysPath, locationsBriefPath, locationsPath, reportPath } = rawFilenames(options);
+
+  if (!fs.existsSync(options.writeTo)) fs.mkdirSync(options.writeTo);
+
+  function writeJson(f, data) {
+    fs.writeFileSync(f, JSON.stringify(data, null, 2));
+  }
+
+  writeJson(locationsPath, locations);
+  writeJson(reportPath, report);
+
+  const keyCollector = locations.reduce((hsh, val) => {
     return { ...hsh, ...val };
   }, {});
-  await fs.writeJSON(path.join(d, `raw-keys${suffix}.json`), Object.keys(keyCollector), { space: 2 });
+  writeJson(keysPath, Object.keys(keyCollector));
 
   // Only pull out a subset of the data for each location.  Since
   // some scrapers put 'null' or 'undefined' for data, do a check to
@@ -49,7 +75,7 @@ export default async function writeRaw(locations, report, options) {
     'todayHospitalized'
   ];
 
-  const output = data.map(d => {
+  const output = locations.map(d => {
     // console.log(`Pruning ${d}`);
     // console.log(`Keys for it: ${Object.keys(d)}`);
     const pruned = {};
@@ -62,9 +88,21 @@ export default async function writeRaw(locations, report, options) {
     }
     return pruned;
   });
-  await fs.writeJSON(path.join(d, `raw${suffix}.json`), output, { space: 2 });
+  writeJson(locationsBriefPath, output);
+}
 
-  await fs.writeJSON(path.join(d, `raw-full${suffix}.json`), data, { space: 2 });
+/** Reconstitute locations and report from old raw JSON files. */
+export function loadRaw(options) {
+  function readJson(f) {
+    if (!f) throw new Error('null file path');
+    if (!fs.existsSync(f)) throw new Error(`Missing raw file ${f}`);
+    const rawdata = fs.readFileSync(f);
+    return JSON.parse(rawdata);
+  }
 
-  await fs.writeJSON(path.join(d, `raw-report${suffix}.json`), report, { space: 2 });
+  const raws = rawFilenames(options);
+  return {
+    locations: readJson(raws.locationsPath),
+    report: readJson(raws.reportPath)
+  };
 }

--- a/src/events/processor/write-data/write-raw.js
+++ b/src/events/processor/write-data/write-raw.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import * as fs from '../../../shared/lib/fs.js';
 
-export default async function writeRawRegression(locations, options) {
+export default async function writeRaw(locations, report, options) {
   if (!options.dumpRaw) return;
 
   let suffix = '';
@@ -65,4 +65,6 @@ export default async function writeRawRegression(locations, options) {
   await fs.writeJSON(path.join(d, `raw${suffix}.json`), output, { space: 2 });
 
   await fs.writeJSON(path.join(d, `raw-full${suffix}.json`), data, { space: 2 });
+
+  await fs.writeJSON(path.join(d, `raw-report${suffix}.json`), report, { space: 2 });
 }

--- a/src/events/processor/write-data/write-raw.js
+++ b/src/events/processor/write-data/write-raw.js
@@ -16,8 +16,11 @@ function rawFilenames(options) {
   }
 
   return {
-    // All keys present in the raw-full file (for debugging/interest)
-    keysPath: path.join(rawDirectory, `raw-keys${suffix}.json`),
+    // All keys present in the locations file (for debugging/interest)
+    locationsKeysPath: path.join(rawDirectory, `raw-locations-keys${suffix}.json`),
+
+    // All keys present in the sources file (for debugging/interest)
+    sourcesKeysPath: path.join(rawDirectory, `raw-sources-keys${suffix}.json`),
 
     // The sources scraped.
     sourcesPath: path.join(rawDirectory, `raw-sources${suffix}.json`),
@@ -41,7 +44,8 @@ export async function writeRaw(sources, locations, report, options) {
 
   const {
     errorReporterErrorsPath,
-    keysPath,
+    locationsKeysPath,
+    sourcesKeysPath,
     sourcesPath,
     locationsBriefPath,
     locationsPath,
@@ -59,10 +63,12 @@ export async function writeRaw(sources, locations, report, options) {
   writeJson(locationsPath, locations);
   writeJson(reportPath, report);
 
-  const keyCollector = locations.reduce((hsh, val) => {
-    return { ...hsh, ...val };
-  }, {});
-  writeJson(keysPath, Object.keys(keyCollector));
+  const keyCollector = arr =>
+    arr.reduce((hsh, val) => {
+      return { ...hsh, ...val };
+    }, {});
+  writeJson(locationsKeysPath, Object.keys(keyCollector(locations)));
+  writeJson(sourcesKeysPath, Object.keys(keyCollector(sources)));
 
   // Only pull out a subset of the data for each location.  Since
   // some scrapers put 'null' or 'undefined' for data, do a check to

--- a/src/shared/cli/rawcombinedreport.js
+++ b/src/shared/cli/rawcombinedreport.js
@@ -1,0 +1,12 @@
+const imports = require('esm')(module);
+
+const { generateReportsFromCombinedRawFiles } = imports('../index.js');
+const argv = imports('./cli-args.js').default;
+const clearAllTimeouts = imports('../utils/timeouts.js').default;
+
+generateReportsFromCombinedRawFiles(argv.date, argv)
+  .then(clearAllTimeouts)
+  .catch(e => {
+    clearAllTimeouts();
+    throw e;
+  });

--- a/src/shared/cli/rawreport.js
+++ b/src/shared/cli/rawreport.js
@@ -1,0 +1,12 @@
+const imports = require('esm')(module);
+
+const { generateReportsFromRawFiles } = imports('../index.js');
+const argv = imports('./cli-args.js').default;
+const clearAllTimeouts = imports('../utils/timeouts.js').default;
+
+generateReportsFromRawFiles(argv.date, argv)
+  .then(clearAllTimeouts)
+  .catch(e => {
+    clearAllTimeouts();
+    throw e;
+  });

--- a/src/shared/cli/rawscrape.js
+++ b/src/shared/cli/rawscrape.js
@@ -1,0 +1,12 @@
+const imports = require('esm')(module);
+
+const { scrapeToRawFiles } = imports('../index.js');
+const argv = imports('./cli-args.js').default;
+const clearAllTimeouts = imports('../utils/timeouts.js').default;
+
+scrapeToRawFiles(argv.date, argv)
+  .then(clearAllTimeouts)
+  .catch(e => {
+    clearAllTimeouts();
+    throw e;
+  });

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -39,12 +39,15 @@ async function generate(date, options = {}) {
   };
 
   // Crawler
-  output = await scrapeData(output);
+  const { locations, scraperErrors } = await scrapeData(sources);
   dumpkeys('after scrape');
-  await writeRawRegression(output.locations, options);
+  await writeRawRegression(locations, options);
 
   // processor
+  output.locations = locations;
   output = await rateSources(output);
+  dumpkeys('after rateSources');
+
   output = await dedupeLocations(output);
   dumpkeys('after dedupeLocations');
 
@@ -54,6 +57,8 @@ async function generate(date, options = {}) {
     errors: validationErrors
   };
 
+  output.sources = sources;
+  output.scraperErrors = scraperErrors;
   output = await reportScrape(output);
   output = await findFeatures(output);
   output = await findPopulations(output);

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -68,7 +68,8 @@ async function generate(date, options = {}) {
 
   await transformIds(locations, output.report, ratings);
 
-  output = await cleanLocations(output);
+  await cleanLocations(locations, output.report);
+
   output.options = options;
   output = await writeData(output); // To be retired
 

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -47,17 +47,16 @@ async function generate(date, options = {}) {
   output.locations = locations;
   const ratings = await rateSources(sources, locations);
 
-  output = await dedupeLocations(output);
-  dumpkeys('after dedupeLocations');
+  const { deDuped, crosscheckReports } = await dedupeLocations(locations);
 
   output.report = report;
   output.report.sources = {
     numSources: sources.length,
     errors: validationErrors
   };
-
   output.sources = sources;
   output.scraperErrors = scraperErrors;
+  output.crosscheckReports = crosscheckReports;
   output = await reportScrape(output);
   output = await findFeatures(output);
   output = await findPopulations(output);

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -70,8 +70,7 @@ async function generate(date, options = {}) {
 
   await cleanLocations(locations, output.report);
 
-  output.options = options;
-  output = await writeData(output); // To be retired
+  output = await writeData(locations, featureResult.featureCollection, ratings, output.report, options); // To be retired
 
   return output;
 }

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -31,18 +31,21 @@ async function generate(date, options = {}) {
     return;
   }
 
+  // Break apart all parts to make connections explicit.
+
   // Crawler
-  const output = await scrapeData(srcs)
-    .then(writeRawRegression)
-    // processor
-    .then(rateSources)
-    .then(dedupeLocations)
-    .then(reportScrape)
-    .then(options.findFeatures !== false && findFeatures)
-    .then(options.findPopulations !== false && findPopulations)
-    .then(transformIds)
-    .then(cleanLocations)
-    .then(options.writeData !== false && writeData); // To be retired
+  let output = await scrapeData(srcs);
+  output = await writeRawRegression(output);
+
+  // processor
+  output = await rateSources(output);
+  output = await dedupeLocations(output);
+  output = await reportScrape(output);
+  output = await findFeatures(output);
+  output = await findPopulations(output);
+  output = await transformIds(output);
+  output = await cleanLocations(output);
+  output = await writeData(output); // To be retired
 
   return output;
 }

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -42,7 +42,7 @@ async function runScrape(sources, date, report, options) {
 
   const locations = await scrapeData(sources, report.scrape);
 
-  await writeRaw(locations, report, options);
+  await writeRaw(sources, locations, report, options);
 
   return locations;
 }
@@ -99,8 +99,6 @@ export async function generateReportsFromRawFiles(date, options = {}) {
   options = getFullOptions(options);
 
   console.log('Restoring locations and report from prior saved raw files.');
-  const { locations, report } = await loadRaw(options);
-  const sources = await getSources(options);
-
+  const { sources, locations, report } = await loadRaw(options);
   return generateReports(date, sources, locations, report, options);
 }

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -66,8 +66,8 @@ async function generate(date, options = {}) {
   const populationResult = await findPopulations(locations, featureResult.featureCollection);
   output.report.findPopulation = populationResult.result;
 
-  output.sourceRatings = ratings;
-  output = await transformIds(output);
+  await transformIds(locations, output.report, ratings);
+
   output = await cleanLocations(output);
   output.options = options;
   output = await writeData(output); // To be retired

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -50,7 +50,6 @@ async function generate(date, options = {}) {
   await reportScrape(locations, scraperErrors, deDuped, crosscheckReports, summaryReport);
 
   const featureResult = await findFeatures(locations);
-  locations = featureResult.locations;
   summaryReport.findFeatures = featureResult.reportResult;
 
   summaryReport.findPopulation = await findPopulations(locations, featureResult.featureCollection);

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -33,18 +33,14 @@ async function generate(date, options = {}) {
 
   // Break apart all parts to make connections explicit.
 
-  let output = { sources };
-  const dumpkeys = title => {
-    console.log(`${title} keys = ${Object.keys(output)}`);
-  };
+  let output = {};
 
   // Crawler
   let { locations, scraperErrors } = await scrapeData(sources);
-  dumpkeys('after scrape');
   await writeRawRegression(locations, options);
 
   // processor
-  output.locations = locations;
+  
   const ratings = await rateSources(sources, locations);
 
   const { deDuped, crosscheckReports } = await dedupeLocations(locations);
@@ -54,10 +50,7 @@ async function generate(date, options = {}) {
     numSources: sources.length,
     errors: validationErrors
   };
-  output.sources = sources;
-  output.scraperErrors = scraperErrors;
-  output.crosscheckReports = crosscheckReports;
-  output = await reportScrape(output);
+  await reportScrape(locations, scraperErrors, deDuped, crosscheckReports, output.report);
 
   const featureResult = await findFeatures(locations);
   locations = featureResult.locations;

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -22,7 +22,7 @@ async function generate(date, options = {}) {
   options = { findFeatures: true, findPopulations: true, writeData: true, ...options };
 
   // Summary of results of each step of generation.
-  let report = {
+  const report = {
     date: date || datetime.getYYYYMD(),
     sources: {},
     scrape: {},
@@ -60,7 +60,7 @@ async function generate(date, options = {}) {
 
   await cleanLocations(locations, report.validate);
 
-  return await writeData(locations, features, ratings, report, options);
+  return writeData(locations, features, ratings, report, options);
 }
 
 export default generate;

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -39,7 +39,7 @@ async function generate(date, options = {}) {
   };
 
   // Crawler
-  const { locations, scraperErrors } = await scrapeData(sources);
+  let { locations, scraperErrors } = await scrapeData(sources);
   dumpkeys('after scrape');
   await writeRawRegression(locations, options);
 
@@ -58,8 +58,13 @@ async function generate(date, options = {}) {
   output.scraperErrors = scraperErrors;
   output.crosscheckReports = crosscheckReports;
   output = await reportScrape(output);
-  output = await findFeatures(output);
-  output = await findPopulations(output);
+
+  const featureResult = await findFeatures(locations);
+  locations = featureResult.locations;
+  output.report.findFeatures = featureResult.reportResult;
+
+  const populationResult = await findPopulations(locations, featureResult.featureCollection);
+  output.report.findPopulation = populationResult.result;
 
   output.sourceRatings = ratings;
   output = await transformIds(output);

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -45,8 +45,7 @@ async function generate(date, options = {}) {
 
   // processor
   output.locations = locations;
-  output = await rateSources(output);
-  dumpkeys('after rateSources');
+  const ratings = await rateSources(sources, locations);
 
   output = await dedupeLocations(output);
   dumpkeys('after dedupeLocations');
@@ -62,10 +61,10 @@ async function generate(date, options = {}) {
   output = await reportScrape(output);
   output = await findFeatures(output);
   output = await findPopulations(output);
+
+  output.sourceRatings = ratings;
   output = await transformIds(output);
   output = await cleanLocations(output);
-  dumpkeys('after cleanLocations');
-
   output.options = options;
   output = await writeData(output); // To be retired
 

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -2,7 +2,7 @@
 import fetchSources from '../events/crawler/get-sources/index.js';
 import validateSources from '../events/crawler/get-sources/validate-sources.js';
 import scrapeData from '../events/crawler/scrape-data/index.js';
-import writeRawRegression from '../events/processor/write-data/dump-regression-raw.js';
+import writeRaw from '../events/processor/write-data/write-raw.js';
 
 // Metadata + geo processing operations
 import rateSources from '../events/processor/rate-sources/index.js';
@@ -39,7 +39,7 @@ async function runScrape(date, report, options) {
 
   const locations = await scrapeData(sources, report.scrape);
 
-  await writeRawRegression(locations, options);
+  await writeRaw(locations, report, options);
 
   return { sources, locations };
 }

--- a/src/shared/lib/diffing/json-diff.js
+++ b/src/shared/lib/diffing/json-diff.js
@@ -109,8 +109,12 @@ function _jsonDiffIter(lhs, rhs, currPath, errs, maxErrors, formatters) {
   } else if (isDictionary(lhs) && isDictionary(rhs)) {
     const lhsKeys = Object.keys(lhs).sort();
     const rhsKeys = Object.keys(rhs).sort();
+    const lhsExtra = lhsKeys.filter(k => !rhsKeys.includes(k));
+    const rhsExtra = rhsKeys.filter(k => !lhsKeys.includes(k));
     if (lhsKeys.toString() !== rhsKeys.toString()) {
-      errs.push(`${newPath}/ keys: [${lhsKeys}] != [${rhsKeys}]`);
+      errs.push(
+        `${newPath}/ keys: [${lhsKeys}] != [${rhsKeys}]; extra left: [${lhsExtra}], extra right: [${rhsExtra}]`
+      );
     } else {
       lhsKeys.forEach(k => {
         _jsonDiffIter(lhs[k], rhs[k], `${newPath}/${k}`, errs, maxErrors, formatters);

--- a/src/shared/lib/error-reporter.js
+++ b/src/shared/lib/error-reporter.js
@@ -19,6 +19,21 @@ const errors = [
   }
 ];
 
+/** Get errors to persist to disk during raw collection. */
+export function getErrors() {
+  return errors;
+}
+
+/** Used to restore errors from a saved file. */
+export function setErrors(arr) {
+  while (errors.length > 0) {
+    errors.pop();
+  }
+  arr.forEach(a => {
+    errors.push(a);
+  });
+}
+
 /**
  * Logs an error.
  *
@@ -69,4 +84,4 @@ function getCSV() {
   return errors;
 }
 
-export default { logError, getCSV };
+export default { logError, getCSV, getErrors, setErrors };

--- a/tests/unit/shared/lib/diffing/json-diff-test.js
+++ b/tests/unit/shared/lib/diffing/json-diff-test.js
@@ -34,13 +34,13 @@ test('diff hash values', t => {
 test('diff hash keys at root', t => {
   lhs = { a: 'apple' };
   rhs = { b: 'bat' };
-  diffShouldBe(t, ['/ keys: [a] != [b]']);
+  diffShouldBe(t, ['/ keys: [a] != [b]; extra left: [a], extra right: [b]']);
 });
 
 test('diff hash keys at child object', t => {
   lhs = { a: 'apple', b: { a: 'apple', c: 'cat' } };
   rhs = { a: 'apple', b: { b: 'bat', c: 'cat' } };
-  diffShouldBe(t, ['/b/ keys: [a,c] != [b,c]']);
+  diffShouldBe(t, ['/b/ keys: [a,c] != [b,c]; extra left: [a], extra right: [b]']);
 });
 
 test('diff values child object', t => {


### PR DESCRIPTION
This is a companion PR for https://github.com/covidatlas/li/pull/89, to generate reports using data from both CDS and Li.

## Summary

This breaks apart the implicit argument passing of src/shared/index.js generate, so that we know what's getting used where.

As a side effect, this allows for scrapes to generate raw data files (in dist-raw), and gives the option to generate the reports using these raw data files.  These are two new cli methods, `raw:scrape` and `raw:report`, so that we don't get confused with these and the existing `yarn start`.

This then adds two another command, `yarn raw:reportcombined` to combine the data from `yarn raw:scrape` (files stored in `dist-raw`) with the data exported from Li using `tools/gen-raw-files` in that project -- see [Li PR 89](https://github.com/covidatlas/li/pull/89/files#diff-3f7f0275f581ac067f87534341aeb4c5) .  When that runs, it loads the sources and data from Li at the top of the report:

```
$ node src/shared/cli/rawcombinedreport.js -d 2020-04-28
Restoring locations and report from prior saved raw files.
Getting Li data
Loading /raw-li-sources-2020-04-28.json
Loading /raw-li-locations-2020-04-28.json
Added 14 sources and 3110 locations from Li.
... etc, report gen continues as usual.
```

The Li sources are given a high priority (100 + old priority).

## Changes

* Major change: breaks apart the implicit argument passing of src/shared/index.js generate, so that we know what's getting used where.
* Changed the function calls to standardize how the "report summary" is built
* Add `raw:scrape`, `raw:report`, `raw:combinedreport` yarn scripts and js files
* Changed raw data output to include all necessary parts so that reports generated from dist-raw have parity with reports generated the usual way.

The diffs look scattered ... the individual commits might be easier to read, to understand the progression of the change.

## Things noted during report generation

Samples of things from console log output, in no particular order:

```
* Crosscheck failed for fips:01123, iso2:us-al, iso1:us: ../../../../li/src/shared/sources/nyt/index.js (99.31372549019608) has different data than US/nyt-counties.js (-0.6862745098039216)

* Crosscheck failed for iso2:us-wy, iso1:us: ../../../../li/src/shared/sources/nyt/index.js (99.27450980392157) has different data than US/nyt-counties.js (-0.7647058823529411)

* Crosscheck passed for fips:29069, iso2:us-mo, iso1:us: ../../../../li/src/shared/sources/nyt/index.js (99.31372549019608) has same data as US/MO/index.js (0.23529411764705882). Logging duplicate.

*  Crosscheck failed for iso2:au-nsw, iso1:au: ../../../../li/src/shared/sources/au/index.js (101.1470588235294) has different data than AU/NSW/index.js (2.215686274509804)
   iso2:au-act, iso1:au: Using ../../../../li/src/shared/sources/au/index.js (101.1470588235294) instead of AU/ACT/index.js (2.176470588235294)
```

## Testing done

I regression tested this by generating reports off of master to dir `zz-master` using cache-only (and turning off my wifi to be sure, because sometimes that skewed results):

```
yarn start --date 2020-04-29 -x --writeTo zz-master
```

and then generating reports using this branch (saving to raw files, and then generating from raw files) to dir `zz-broken-chain`:

```
yarn raw:scrape --date 2020-04-29 -x
yarn raw:report --date 2020-04-29 -x --writeTo zz-broken-chain
```

Then I checked with the regression tool `node tools/compare-report-dirs.js --left zz-master --right zz-broken-chain/`, and all were equal.

I've only checked the above date, but can cycle through all of them if needed.

