### PR TITLE
Add timeseries writeTo support, fix comparison

### DIFF
--- a/src/shared/timeseries/index.js
+++ b/src/shared/timeseries/index.js
@@ -89,7 +89,7 @@ async function generateTidyCSV(timeseriesByLocation) {
 
   csvData.splice(0, 0, columns);
 
-  return fs.writeCSV(path.join('dist', 'timeseries-tidy.csv'), csvData);
+  return csvData;
 }
 
 async function generateCSV(timeseriesByLocation) {
@@ -145,7 +145,7 @@ async function generateCSV(timeseriesByLocation) {
 
   csvData.splice(0, 0, columns);
 
-  return fs.writeCSV(path.join('dist', 'timeseries.csv'), csvData);
+  return csvData;
 }
 
 async function generateJHUCSV(timeseriesByLocation) {
@@ -189,7 +189,7 @@ async function generateJHUCSV(timeseriesByLocation) {
   columns = columns.concat(dates);
   csvData.splice(0, 0, columns);
 
-  return fs.writeCSV(path.join('dist', 'timeseries-jhu.csv'), csvData);
+  return csvData;
 }
 
 function getGrowthfactor(casesToday, casesYesterday) {
@@ -270,11 +270,15 @@ async function generateTimeseries(options = {}) {
   await fs.writeJSON(path.join('dist', `timeseries.json`), timeseriesByDate, { space: 2 });
   await fs.writeJSON(path.join('dist', `locations.json`), locations, { space: 2 });
 
-  await generateCSV(timeseriesByLocation);
+  let csvData = null;
+  csvData = await generateCSV(timeseriesByLocation);
+  await fs.writeCSV(path.join('dist', 'timeseries.csv'), csvData);
 
-  await generateTidyCSV(timeseriesByLocation);
+  csvData = await generateTidyCSV(timeseriesByLocation);
+  await fs.writeCSV(path.join('dist', 'timeseries-tidy.csv'), csvData);
 
-  await generateJHUCSV(timeseriesByLocation);
+  csvData = await generateJHUCSV(timeseriesByLocation);
+  await fs.writeCSV(path.join('dist', 'timeseries-jhu.csv'), csvData);
 }
 
 generateTimeseries(argv)

--- a/src/shared/timeseries/index.js
+++ b/src/shared/timeseries/index.js
@@ -263,22 +263,25 @@ async function generateTimeseries(options = {}) {
     previousDate = date;
   }
 
-  await fs.writeJSON(path.join('dist', 'timeseries-byLocation.json'), timeseriesByLocation, { space: 0 });
-  await fs.writeJSON(path.join('dist', 'features.json'), featureCollection, { space: 0 });
+  const d = options.writeTo;
+  await fs.ensureDir(d);
+
+  await fs.writeJSON(path.join(d, 'timeseries-byLocation.json'), timeseriesByLocation, { space: 0 });
+  await fs.writeJSON(path.join(d, 'features.json'), featureCollection, { space: 0 });
 
   const { locations, timeseriesByDate } = transform.transposeTimeseries(timeseriesByLocation);
-  await fs.writeJSON(path.join('dist', `timeseries.json`), timeseriesByDate, { space: 2 });
-  await fs.writeJSON(path.join('dist', `locations.json`), locations, { space: 2 });
+  await fs.writeJSON(path.join(d, `timeseries.json`), timeseriesByDate, { space: 2 });
+  await fs.writeJSON(path.join(d, `locations.json`), locations, { space: 2 });
 
   let csvData = null;
   csvData = await generateCSV(timeseriesByLocation);
-  await fs.writeCSV(path.join('dist', 'timeseries.csv'), csvData);
+  await fs.writeCSV(path.join(d, 'timeseries.csv'), csvData);
 
   csvData = await generateTidyCSV(timeseriesByLocation);
-  await fs.writeCSV(path.join('dist', 'timeseries-tidy.csv'), csvData);
+  await fs.writeCSV(path.join(d, 'timeseries-tidy.csv'), csvData);
 
   csvData = await generateJHUCSV(timeseriesByLocation);
-  await fs.writeCSV(path.join('dist', 'timeseries-jhu.csv'), csvData);
+  await fs.writeCSV(path.join(d, 'timeseries-jhu.csv'), csvData);
 }
 
 generateTimeseries(argv)

--- a/tools/compare-report-dirs.js
+++ b/tools/compare-report-dirs.js
@@ -160,9 +160,6 @@ function compareReportFolders(left, right) {
     },
 
     { regex: /timeseries-byLocation.json/, formatters: {} },
-    { regex: /timeseries-jhu.csv/, formatters: {} },
-    { regex: /timeseries-tidy.csv/, formatters: {} },
-    { regex: /timeseries.csv/, formatters: {} },
     { regex: /timeseries.json/, formatters: {} }
   ];
 
@@ -173,7 +170,13 @@ function compareReportFolders(left, right) {
     }
   });
 
-  const csvReports = [/crawler-report.csv/, /data(.*).csv/];
+  const csvReports = [
+    /crawler-report.csv/,
+    /data(.*).csv/,
+    /timeseries.csv/,
+    /timeseries-tidy.csv/,
+    /timeseries-jhu.csv/
+  ];
   csvReports.forEach(regex => {
     const [left, right] = findLeftRightFiles(regex, leftPaths, rightPaths);
     if (left && right) {


### PR DESCRIPTION
This is useful for regression.

Example usage: `yarn timeseries -d 2020-5-6 -e 2020-5-6 --writeTo zzTIMESERIES`

If --writeTo isn't specified, it writes to dist.

This also fixes the report comparison tool, minor tweaks, for timeseries regression, eg

`node tools/compare-report-dirs.js --left dist --right zzTIMESERIES/`