### PR TITLE
Update TW URL description

### DIFF
--- a/src/shared/scrapers/TW/index.js
+++ b/src/shared/scrapers/TW/index.js
@@ -13,7 +13,7 @@ const scraper = {
     {
       name: 'Taiwan CDC',
       url: 'https://sites.google.com/cdc.gov.tw/2019-ncov/taiwan',
-      description: ''
+      description: 'Taiwan CDC'
     }
   ],
   type: 'json',


### PR DESCRIPTION
Hi Guys,

So we're using this as a datasource for our serverless API ([CoronaAPI/coronaAWS](https://github.com/coronaapi/coronaaws)).

When executing the scraper and importing the resulting data into DynamoDB however, the import fails due to the empty string in this specific crawler.

Hope this is alright!
