### PR TITLE
Fix CA/NS.

### DIFF
--- a/src/shared/scrapers/CA/NS/index.js
+++ b/src/shared/scrapers/CA/NS/index.js
@@ -2,7 +2,9 @@ import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import * as geography from '../../../lib/geography/index.js';
 import datetime from '../../../lib/datetime/old/index.js';
-import { NotImplementedError } from '../../../lib/errors.js';
+
+const csvParse = require('csv-parse/lib/sync');
+const assert = require('assert');
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -21,17 +23,38 @@ const scraper = {
   ],
   scraper: {
     '0': async function() {
-      const data = await fetch.csv(this, this.url, 'default');
+      // The filename is COVID-19-data.csv, but it's not actually valid CSV ...
+      // The first line appears to be obsolete headings, and the actual CSV starts on line 2.
+      const rawdata = await fetch.raw(this, 'https://novascotia.ca/coronavirus/data/COVID-19-data.csv', 'default');
+      const data = csvParse(rawdata, { columns: true, from_line: 2 });
 
-      const headers = Object.keys(data[0]);
-      if (headers[0] !== 'Date' || headers[1] !== 'Positive' || headers[2] !== 'Negative') {
-        throw new Error('Unknown headers in CSV');
-      }
+      // The numbers in the data seem to match the totals shown on
+      // https://novascotia.ca/coronavirus/data/, but they appear to
+      // be handled differently.  In this data:
+      // - Cases = _new_ cases for date
+      // - Deaths = _new_ deaths for date
+      // - Negative = total negative to date
+      // - Recovered = recovered to date
+      // - non-ICU + ICU = current hospitalized
+      const expectedHeadings = ['Date', 'Cases', 'Negative', 'Recovered', 'non-ICU', 'ICU', 'Deaths'];
+      const missingExpected = expectedHeadings.filter(h => {
+        return !Object.keys(data[0]).includes(h);
+      });
+      assert.equal(missingExpected.length, 0, `Missing headings ${missingExpected.join()}`);
 
-      // FIXME when we roll out new TZ support!
-      const fallback = process.env.USE_ISO_DATETIME ? new Date(datetime.now.at('America/Halifax')) : datetime.getDate();
-      let scrapeDate = process.env.SCRAPE_DATE ? new Date(`${process.env.SCRAPE_DATE} 12:00:00`) : fallback;
-      let scrapeDateString = datetime.getYYYYMD(scrapeDate);
+      // TODO (timezone) Have to interpret all date/times as 'America/Halifax' in Li
+      const dt = new Date();
+      const zeroPad = (num, places = 2) => String(num).padStart(places, '0');
+      // en-US date = eg "12/19/2012"
+      const [m, d, y] = dt
+        .toLocaleDateString('en-US')
+        .split('/')
+        .map(n => zeroPad(n));
+      const today = [y, m, d].join('-');
+
+      let scrapeDate = process.env.SCRAPE_DATE || today;
+      let scrapeDateString = datetime.getYYYYMMDD(scrapeDate);
+
       const lastDateInTimeseries = new Date(`${data[data.length - 1].Date} 12:00:00`);
       const firstDateInTimeseries = new Date(`${data[0].Date} 12:00:00`);
 
@@ -51,23 +74,30 @@ const scraper = {
         throw new Error(`Timeseries starts later than SCRAPE_DATE ${scrapeDateString}`);
       }
 
-      for (const row of data) {
-        if (datetime.getYYYYMD(`${row.Date} 12:00:00`) === scrapeDateString) {
-          const pos = parse.number(row.Positive);
-          const neg = parse.number(row.Negative);
+      const dataToDate = data.filter(row => {
+        return row.Date <= scrapeDate;
+      });
 
-          return {
-            cases: pos,
-            tested: pos + neg
+      let totalCases = 0;
+      let totalDeaths = 0;
+      let result = {};
+      for (const row of dataToDate) {
+        totalCases += parse.number(row.Cases);
+        totalDeaths += parse.number(row.Deaths);
+        if (row.Date === scrapeDateString) {
+          result = {
+            cases: totalCases,
+            tested: parse.number(row.Negative),
+            recovered: parse.number(row.Recovered),
+            deaths: totalDeaths
           };
         }
       }
+      if (Object.keys(result).length > 0) {
+        console.table(result);
+        return result;
+      }
       throw new Error(`Timeseries does not contain a sample for SCRAPE_DATE ${scrapeDateString}`);
-    },
-    '2020-04-12': async function() {
-      this.url = 'https://novascotia.ca/coronavirus/data/COVID-19-data.csv';
-      await fetch.csv(this, this.url, 'default');
-      throw new NotImplementedError('Someone needs to scrape this new data properly');
     }
   }
 };

--- a/src/shared/scrapers/CA/NS/index.js
+++ b/src/shared/scrapers/CA/NS/index.js
@@ -14,6 +14,7 @@ const scraper = {
   country: 'iso1:CA',
   url: 'https://novascotia.ca/coronavirus/COVID-19-cases.csv',
   type: 'csv',
+  timeseries: true,
   certValidation: false,
   sources: [
     {


### PR DESCRIPTION
Was throwing "not implemented".  Using a new timeseries for NS.

Yarn start now gives

```
┌───────────┬────────┐
│  (index)  │ Values │
├───────────┼────────┤
│   cases   │  1037  │
│  tested   │ 35703  │
│ recovered │  930   │
│  deaths   │   55   │
└───────────┴────────┘
```

