### PR TITLE
Show deaths rate in addition to confirmed cases rate

### DIFF
--- a/site/lib/color.js
+++ b/site/lib/color.js
@@ -153,7 +153,7 @@ export function createLegend(min, max, legendType) {
 
   const heading = document.createElement('span');
   heading.className = 'spectrum-Heading spectrum-Heading--XXXS';
-  heading.innerHTML = 'Percent of population ' + legendType;
+  heading.innerHTML = `Percent of population ${legendType}`;
   container.appendChild(heading);
 
   base.appendChild(container);

--- a/site/lib/color.js
+++ b/site/lib/color.js
@@ -144,7 +144,7 @@ export function getScaledColorValue(location, locationData, type, worstAffectedP
   return fill(percentRatio);
 }
 
-export function createLegend(min, max) {
+export function createLegend(min, max, legendType) {
   const base = document.getElementById('map');
   const containerId = 'mapLegend';
   const container = base.querySelector(`#${containerId}`) || document.createElement('div');
@@ -153,7 +153,7 @@ export function createLegend(min, max) {
 
   const heading = document.createElement('span');
   heading.className = 'spectrum-Heading spectrum-Heading--XXXS';
-  heading.innerHTML = 'Percent of population infected';
+  heading.innerHTML = 'Percent of population ' + legendType;
   container.appendChild(heading);
 
   base.appendChild(container);

--- a/site/map.js
+++ b/site/map.js
@@ -92,7 +92,7 @@ function setData() {
 }
 
 function updateMap(date, type) {
-  currentType = type || 'cases';
+  currentType = type || currentType;
   currentDate = date || Object.keys(data.timeseries).pop();
   currentData = data.timeseries[currentDate];
 
@@ -109,11 +109,12 @@ function updateMap(date, type) {
     if (location.population) {
       const locationData = currentData[index];
       if (locationData) {
-        const infectionPercent = locationData.cases / location.population;
+        const infectionPercent = locationData[currentType] / location.population;
         if (infectionPercent > worstAffectedPercent) {
           worstAffectedPercent = infectionPercent;
           highestLocation = location;
         }
+        //worstAffectedPercent = 0.002
         // Calculate least affected percent
         if (infectionPercent !== 0 && infectionPercent < lowestInfectionPercent) {
           lowestInfectionPercent = infectionPercent;
@@ -132,7 +133,7 @@ function updateMap(date, type) {
     if (location && location.population) {
       const locationData = currentData[locationId];
       if (locationData) {
-        if (locationData.cases === 0) {
+        if (locationData[currentType] === 0) {
           regionColor = color.noCasesColor;
         } else {
           regionColor = color.getScaledColorValue(location, locationData, currentType, worstAffectedPercent);
@@ -146,7 +147,7 @@ function updateMap(date, type) {
   console.log('Lowest infection', lowestLocation);
   console.log('Highest infection', highestLocation);
 
-  color.createLegend(chartDataMin, chartDataMax);
+  color.createLegend(chartDataMin, chartDataMax, currentType == 'deaths' ? 'passed away' : 'infected');
 
   setData();
 }
@@ -179,6 +180,12 @@ function populateMap() {
     if (location.population && locationData.cases) {
       htmlString += `<tr><th>Infected:</th><td>${getRatio(locationData.cases, location.population)} (${getPercent(
         locationData.cases,
+        location.population
+      )})</td></tr>`;
+    }
+    if (location.population && locationData.deaths) {
+      htmlString += `<tr><th>Deaths:</th><td>${getRatio(locationData.deaths, location.population)} (${getPercent(
+        locationData.deaths,
         location.population
       )})</td></tr>`;
     }
@@ -331,6 +338,34 @@ function populateMap() {
   }
 
   map.addControl(new DateSelector(), 'top-right');
+
+  // Case thpe selector
+  class CaseTypeSelector {
+    onAdd() {
+      this._container = document.createElement('div');
+      this._container.className = 'mapboxgl-ctrl cds-MapControl';
+      this._container.innerHTML = `<label class="cds-MapToggle"><input type="checkbox">Show Deaths</label>`;
+
+      this._container.addEventListener('change', evt => {
+        const { target } = evt;
+        
+        if (target.checked) {
+          currentType = 'deaths';
+        } else {
+          currentType = 'cases';
+        }
+        updateMap(currentDate, currentType);
+      });
+ 
+      return this._container;
+    }
+
+    onRemove() {
+        this._container.parentNode.removeChild(this._container);
+      }
+  }
+
+  map.addControl(new CaseTypeSelector(), 'top-left');
 
   setData();
 

--- a/site/map.js
+++ b/site/map.js
@@ -114,7 +114,7 @@ function updateMap(date, type) {
           worstAffectedPercent = infectionPercent;
           highestLocation = location;
         }
-        //worstAffectedPercent = 0.002
+
         // Calculate least affected percent
         if (infectionPercent !== 0 && infectionPercent < lowestInfectionPercent) {
           lowestInfectionPercent = infectionPercent;
@@ -147,7 +147,7 @@ function updateMap(date, type) {
   console.log('Lowest infection', lowestLocation);
   console.log('Highest infection', highestLocation);
 
-  color.createLegend(chartDataMin, chartDataMax, currentType == 'deaths' ? 'passed away' : 'infected');
+  color.createLegend(chartDataMin, chartDataMax, currentType === 'deaths' ? 'passed away' : 'infected');
 
   setData();
 }
@@ -348,7 +348,7 @@ function populateMap() {
 
       this._container.addEventListener('change', evt => {
         const { target } = evt;
-        
+
         if (target.checked) {
           currentType = 'deaths';
         } else {
@@ -356,13 +356,13 @@ function populateMap() {
         }
         updateMap(currentDate, currentType);
       });
- 
+
       return this._container;
     }
 
     onRemove() {
-        this._container.parentNode.removeChild(this._container);
-      }
+      this._container.parentNode.removeChild(this._container);
+    }
   }
 
   map.addControl(new CaseTypeSelector(), 'top-left');

--- a/site/map.js
+++ b/site/map.js
@@ -344,16 +344,16 @@ function populateMap() {
     onAdd() {
       this._container = document.createElement('div');
       this._container.className = 'mapboxgl-ctrl cds-MapControl';
-      this._container.innerHTML = `<label class="cds-MapToggle"><input type="checkbox">Show Deaths</label>`;
+      this._container.innerHTML = `
+        <select>
+          <option value="cases">Cases</option>
+          <option value="deaths" >Deaths</option>
+        </select>
+      `;
 
       this._container.addEventListener('change', evt => {
         const { target } = evt;
-
-        if (target.checked) {
-          currentType = 'deaths';
-        } else {
-          currentType = 'cases';
-        }
+        currentType = target.value;
         updateMap(currentDate, currentType);
       });
 

--- a/site/map.js
+++ b/site/map.js
@@ -347,7 +347,7 @@ function populateMap() {
       this._container.innerHTML = `
         <select>
           <option value="cases">Cases</option>
-          <option value="deaths" >Deaths</option>
+          <option value="deaths">Deaths</option>
         </select>
       `;
 


### PR DESCRIPTION
This should add an option to show the death rate per population in addition to the confirmed infected cases, as shown here:

![pr-cases-deaths](https://user-images.githubusercontent.com/169821/82164184-8964ba00-98af-11ea-9565-f8780b25bde7.gif)

