### PR TITLE
Replace San Francisco scraper with official API

### DIFF
--- a/src/shared/lib/maintainers.js
+++ b/src/shared/lib/maintainers.js
@@ -86,6 +86,17 @@ const maintainers = {
     county: 'Ventura County',
     city: 'Ventura',
     flag: '🇺🇸'
+  },
+  '1ec5': {
+    name: 'Minh Nguyễn',
+    url: 'http://notes.1ec5.org/',
+    github: '1ec5',
+    twitter: '1ec5',
+    country: 'USA',
+    state: 'CA',
+    county: 'Santa Clara County',
+    city: 'San José',
+    flag: '🇺🇸'
   }
 };
 

--- a/src/shared/scrapers/US/CA/san-francisco-county.js
+++ b/src/shared/scrapers/US/CA/san-francisco-county.js
@@ -1,5 +1,5 @@
 import * as fetch from '../../../lib/fetch/index.js';
-import * as parse from '../../../lib/parse.js';
+import datetime from '../../../lib/datetime/index.js';
 import maintainers from '../../../lib/maintainers.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
@@ -9,26 +9,99 @@ const scraper = {
   county: 'San Francisco County',
   state: 'iso2:US-CA',
   country: 'iso1:US',
-  maintainers: [maintainers.jbencina],
-  url: 'https://www.sfdph.org/dph/alerts/coronavirus.asp',
-  type: 'paragraph',
-  async scraper() {
-    let deaths;
-    let cases;
-    const $ = await fetch.page(this, this.url, 'default');
-    const $h2 = $('h2:contains("Cases in San Francisco")');
+  maintainers: [maintainers['1ec5']],
+  type: 'json',
+  timeseries: true,
+  headless: false,
+  sources: [
     {
-      const $p = $h2.nextAll('*:contains("Cases:")');
-      cases = parse.number($p.text());
-    }
+      name: 'San Francisco Department of Public Health',
+      url: 'https://data.sfgov.org/COVID-19/COVID-19-Cases-Summarized-by-Date-Transmission-and/tvq9-ec9w',
+      description: 'COVID-19 Cases Summarized by Date, Transmission and Case Disposition'
+    },
     {
-      const $p = $h2.nextAll('*:contains("Deaths:")');
-      deaths = parse.number($p.text());
+      name: 'San Francisco Department of Public Health',
+      url: 'https://data.sfgov.org/COVID-19/COVID-19-Hospitalizations/nxjg-bhem',
+      description: 'COVID-19 Hospitalizations'
+    },
+    {
+      name: 'San Francisco Department of Public Health',
+      url: 'https://data.sfgov.org/COVID-19/COVID-19-Tests/nfpa-mg4g',
+      description: 'COVID-19 Tests'
     }
-    return {
-      cases,
-      deaths
-    };
+  ],
+  url: 'https://data.sfgov.org/stories/s/dak2-gvuj',
+  _urls: {
+    cases: 'https://data.sfgov.org/resource/tvq9-ec9w.json',
+    patients: 'https://data.sfgov.org/resource/nxjg-bhem.json',
+    tests: 'https://data.sfgov.org/resource/nfpa-mg4g.json'
+  },
+  scraper: {
+    '0': async function() {
+      const cases = await fetch.json(this, this._urls.cases, 'default', false);
+      const patients = await fetch.json(this, this._urls.patients, 'default', false);
+      const tests = await fetch.json(this, this._urls.tests, 'default', false);
+      const timeSeries = {};
+      cases.reduceRight(
+        (acc, cur) => {
+          const date = datetime.getYYYYMMDD(cur.date);
+          const field = cur.case_disposition === 'Death' ? 'deaths' : 'cases';
+          acc[field] += +cur.case_count;
+          if (!(date in timeSeries)) {
+            timeSeries[date] = {};
+          }
+          timeSeries[date][field] = acc[field];
+          return acc;
+        },
+        {
+          cases: 0,
+          deaths: 0
+        }
+      );
+      patients.forEach(elt => {
+        const date = datetime.getYYYYMMDD(elt.reportdate);
+        if (!(date in timeSeries)) {
+          timeSeries[date] = {};
+        }
+        if (elt.patientcount) {
+          if (!('hospitalized' in timeSeries[date])) {
+            timeSeries[date].hospitalized = 0;
+          }
+          timeSeries[date].hospitalized += +elt.patientcount;
+        }
+      });
+      tests.reduceRight((acc, cur) => {
+        const date = datetime.getYYYYMMDD(cur.result_date);
+        acc += +cur.tests;
+        if (!(date in timeSeries)) {
+          timeSeries[date] = {};
+        }
+        timeSeries[date].tested = acc;
+        return acc;
+      }, 0);
+
+      let scrapeDate = datetime.scrapeDate() || new Date();
+      let scrapeDateString = datetime.getYYYYMMDD(new Date(scrapeDate));
+      const datesInTimeseries = Object.keys(timeSeries).sort();
+      const lastDateInTimeseries = new Date(datesInTimeseries.slice(-1)[0]);
+      const firstDateInTimeseries = new Date(datesInTimeseries[0]);
+
+      if (datetime.scrapeDateIsAfter(lastDateInTimeseries)) {
+        console.error(
+          `  🚨 timeseries for San Francisco County: SCRAPE_DATE ${datetime.getYYYYMMDD(
+            scrapeDate
+          )} is newer than last sample time ${datetime.getYYYYMMDD(lastDateInTimeseries)}. Using last sample anyway`
+        );
+        scrapeDate = lastDateInTimeseries;
+        scrapeDateString = datetime.getYYYYMMDD(scrapeDate);
+      }
+
+      if (datetime.scrapeDateIsBefore(firstDateInTimeseries)) {
+        throw new Error(`Timeseries starts later than SCRAPE_DATE ${datetime.getYYYYMMDD(scrapeDate)}`);
+      }
+
+      return timeSeries[scrapeDateString];
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/san-francisco-county.js
+++ b/src/shared/scrapers/US/CA/san-francisco-county.js
@@ -38,9 +38,9 @@ const scraper = {
   },
   scraper: {
     '0': async function() {
-      const cases = await fetch.json(this, this._urls.cases, 'default', false);
-      const patients = await fetch.json(this, this._urls.patients, 'default', false);
-      const tests = await fetch.json(this, this._urls.tests, 'default', false);
+      const cases = await fetch.json(this, this._urls.cases, 'cases', false);
+      const patients = await fetch.json(this, this._urls.patients, 'patients', false);
+      const tests = await fetch.json(this, this._urls.tests, 'tests', false);
       const timeSeries = {};
       cases.reduceRight(
         (acc, cur) => {


### PR DESCRIPTION
<!---
Hi there!  Some things to double-check prior to submission:

- did you recently update this branch with upstream master,
  to ensure everything works together?
- did you `yarn lint` ?
- did you `yarn test` ?
- have you added any new tape tests to verify your change?
- did you update any relevant documentation?
-->

## Summary

<!-- What is this change about?  If it's related to an issue, please include the issue number (e.g., #426) -->

Replaced the scraper for the City and County of San Francisco with a new implementation that joins and pivots three datasets provided by the city’s DataSF portal in JSON format through an official API:

* [COVID-19 Cases Summarized by Date, Transmission and Case Disposition](https://data.sfgov.org/COVID-19/COVID-19-Cases-Summarized-by-Date-Transmission-and/tvq9-ec9w/)
* [COVID-19 Hospitalizations](https://data.sfgov.org/COVID-19/COVID-19-Hospitalizations/nxjg-bhem)
* [COVID-19 Tests](https://data.sfgov.org/COVID-19/COVID-19-Tests/nfpa-mg4g)

<!-- Short description, before this change ... -->
Previously, this project scraped the Department of Public Health’s COVID-19 landing page for the current statistics. The page didn’t provide any historical data, so this project would cache past days’ values of the current case total, and clients would tend to treat those values as the actual infection totals as of those days.

<!-- Short description, after this change ... -->
Now the project pulls in the full time series as revised by the department each day, which is optimal for charting infection rates. It also adds hospitalization and test counts.

Fixes #1011.

## Changes

This implementation pivots each dataset on the date field, summing case counts and distinguishing between case count and death toll for the first dataset.

## Additional notes

<!--
  * mention any test coverage added or changed
  * what are success/failure conditions?
  * are there any side effects?
-->

<!-- Erase any parts of this template if they're not applicable.  Cheers! -->
