### PR TITLE
Add testing counts to US/MO

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -431,7 +431,7 @@ You should run your source with the crawler by running `yarn start -l "<path to 
 
 The path to scraper should be the relative path under
 `src/shared/scrapers`; e.g., the scraper for Montana, USA would be
-"US/MO").
+"US/MT").
 
 After the crawler has finished running, look at how many counties, states, and countries were
 scraped. Also look for missing location or population information. Finally, look at the output located in the `dist` directory. `data.json` contains all the information

--- a/src/shared/scrapers/US/MO/index.js
+++ b/src/shared/scrapers/US/MO/index.js
@@ -229,7 +229,7 @@ const scraper = {
 
     const orgId = 'Bd4MACzvEukoZ9mR';
     const layoutName = 'Daily_COVID19_Testing_Report_for_OPI';
-    const cumulativeResults = await fetch.queryArcGISJSON(this, 6, orgId, layoutName, queryParams);
+    const cumulativeResults = await fetch.queryArcGISJSON(this, 6, orgId, layoutName, queryParams, false);
     cumulativeResults.features.forEach(testFeatures => {
       const testRow = testFeatures.attributes;
       const countyName = testRow.county;

--- a/tests/integration/scrapers/scrapers-new-test.js
+++ b/tests/integration/scrapers/scrapers-new-test.js
@@ -34,6 +34,7 @@ if (files) {
           const hasErrors = schema.schemaHasErrors(scraper.default, schema.schemas.scraperSchema);
           t.notOk(hasErrors, 'Scraper had no errors');
         } catch (err) {
+          console.log(err);
           t.fail(`Scraper failed with error: ${err}`);
         }
         t.end();


### PR DESCRIPTION
## Summary

Adds testing county-level test counts to Missouri state data

Previously, testing counts were not collected at the county level

This change adds that by pulling from 

## Changes

- Add a new utility function for querying arcGIS data sources, handles pagination.
- Add a function to scrapers/US/MO.index.js that enhances the existing case and death count data for the county with testing counts