### PR TITLE
Harris county tx

### DIFF
--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -162,17 +162,29 @@ export const pdf = async (scraper, url, cacheKey = 'default', date, options) => 
   return data;
 };
 
-export const fetchHeadlessPage = async (url, callback) => {
+/**
+ * Load a url in headless browser, call user-supplied callback, return callback's output
+ * @param {*} scraper the scraper object
+ * @param {string} url URL of the resource
+ * @param {null} cacheKey The cache key -- this is IGNORED by this function as data is dynamically extrated and cannot be cached
+ * @param {function} callback The callback to be used on open page. Should accept a single argument `page` that is a puppeteer page that has been loaded with the given url
+ */
+export const fetchHeadlessCallback = async (scraper, url, callback, cacheKey = null) => {
+  if (cacheKey !== null) {
+    throw new Error(
+      'cacheKey is ignored in fetchHeadlessCallback as data is dynamically extracted by callback each time the function is called'
+    );
+  }
   log('  🤹‍♂️  Loading data for %s from server with a headless browser', url);
-
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-
-  await page.setUserAgent(CHROME_AGENT);
-  await page.setViewport(DEFAULT_VIEWPORT);
 
   let tries = 0;
   while (tries < 5) {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+
+    await page.setUserAgent(CHROME_AGENT);
+    await page.setViewport(DEFAULT_VIEWPORT);
+
     tries++;
     if (tries > 1) {
       // sleep a moment before retrying
@@ -224,7 +236,7 @@ export const fetchHeadlessPage = async (url, callback) => {
 };
 
 const fetchHeadless = async url => {
-  return fetchHeadlessPage(url, async page => {
+  return fetchHeadlessCallback(null, url, async page => {
     const html = await page.content();
     return html;
   });

--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -201,7 +201,7 @@ export const fetchHeadlessPage = async (url, callback) => {
       // We got a good response, return it
       if (response.status() < 400) {
         await page.waitFor(RESPONSE_TIMEOUT);
-        const out = callback(page);
+        const out = await callback(page);
         browser.close();
         return out;
       }

--- a/src/shared/lib/fetch/index.js
+++ b/src/shared/lib/fetch/index.js
@@ -162,7 +162,7 @@ export const pdf = async (scraper, url, cacheKey = 'default', date, options) => 
   return data;
 };
 
-const fetchHeadless = async url => {
+export const fetchHeadlessPage = async (url, callback) => {
   log('  🤹‍♂️  Loading data for %s from server with a headless browser', url);
 
   const browser = await puppeteer.launch();
@@ -201,9 +201,9 @@ const fetchHeadless = async url => {
       // We got a good response, return it
       if (response.status() < 400) {
         await page.waitFor(RESPONSE_TIMEOUT);
-        const html = await page.content();
+        const out = callback(page);
         browser.close();
-        return html;
+        return out;
       }
 
       // 400-499 means "not found", retrying is not likely to help
@@ -221,6 +221,13 @@ const fetchHeadless = async url => {
 
   log.error(`  ❌ Failed to fetch ${url} after ${tries} tries`);
   return null;
+};
+
+const fetchHeadless = async url => {
+  return fetchHeadlessPage(url, async page => {
+    const html = await page.content();
+    return html;
+  });
 };
 
 /**

--- a/src/shared/scrapers/US/TX/harris-county.js
+++ b/src/shared/scrapers/US/TX/harris-county.js
@@ -87,16 +87,28 @@ const scraper = {
         await page.waitFor(2000);
         await tableButton.click();
 
-        console.log('I have a table button:', tableButton);
-
         // Get the data
         const data = await page.waitForXPath("//div[@aria-label='Grid']").then(getDataFromPivotTable);
 
         // return now as we don't need the browser anymore
         return data;
       };
-
+      // fetch raw data
       const data = await fetch.fetchHeadlessPage(this.url, callback);
+
+      // Now parse it out
+      const dates = data.dates.map(x => new Date(x));
+      // const nRows = dates.length;
+      console.log(dates);
+
+      /* TODO:
+
+      1. find index for date: `ix`
+      2. Get data for column `i` (starting at 0) via `nRows * i + (ix-1)`
+      3. Set output via column headers.
+
+      */
+
       console.log(data);
     }
   }

--- a/src/shared/scrapers/US/TX/harris-county.js
+++ b/src/shared/scrapers/US/TX/harris-county.js
@@ -1,0 +1,105 @@
+import * as fetch from '../../../lib/fetch/index.js';
+// import datetime from '../../../lib/datetime/index.js';
+import maintainers from '../../../lib/maintainers.js';
+
+// Construct xpath condition for containing a class
+const classCheck = x => `contains(concat(' ',normalize-space(@class),' '),' ${x} ')`;
+
+// Extract the text value of the puppeteer element
+async function getTextcontent(el) {
+  const out = await (await el.getProperty('textContent')).jsonValue();
+  return out;
+}
+
+// Get cell values from part of a PowerBI pivot table.
+// Use `parentClassName = 'columnHeaders'` to get column names,
+//     `parentClassName = 'rowHeaders'` for row labels
+//     `parentClassName = 'bodyCells'` for actual body of the table
+async function _getTableVals(el, parentClassName) {
+  const elements = await el.$x(`//div[@class='${parentClassName}']//div[${classCheck('pivotTableCellWrap')}]`);
+  return Promise.all(elements.map(getTextcontent));
+}
+
+// Get the values from a PowerBI pivotTable, given the puppeteer elementHandle for the table div
+const getDataFromPivotTable = async el => {
+  // check that we have Date
+  const indexName = await el.$x(`//div[@class='corner']//div[${classCheck('pivotTableCellWrap')}]`);
+  if (indexName.length !== 1) {
+    throw Error(`Found ${indexName.length} index names, expected 1`);
+  }
+  const indexNameVal = await getTextcontent(indexName[0]);
+  console.log(indexNameVal);
+  if (indexNameVal.trim() !== 'Date') {
+    throw Error(`Expected index name to be Date, found ${indexNameVal}`);
+  }
+
+  // get column names
+  return {
+    colnames: await _getTableVals(el, 'columnHeaders'),
+    dates: await _getTableVals(el, 'rowHeaders'),
+    data: await _getTableVals(el, 'bodyCells')
+  };
+};
+
+const scraper = {
+  county: 'fips:48201',
+  state: 'iso2:US-TX',
+  country: 'iso1:US',
+  url:
+    'https://app.powerbi.com/view?r=eyJrIjoiYjU5MzU4NjAtZWJjMC00MTllLTkwYjYtMzE4ODY1YjAyMGU2IiwidCI6ImI3MjgwODdjLTgwZTgtNGQzMS04YjZmLTdlMGUzYmUxMGUwOCIsImMiOjN9',
+  sources: [
+    {
+      name: 'SouthEast Texas Regional Advisory Council',
+      url: 'https://www.setrac.org/',
+      description: 'SouthEast Texas Regional Advisory Council'
+    }
+  ],
+  _counties: ['Harris County'],
+  timeseries: true,
+  aggregate: 'county',
+  type: 'json',
+  maintainers: [maintainers.sglyon],
+  scraper: {
+    '0': async function() {
+      const callback = async page => {
+        // Wait for ICU button to load then navigate to that page
+        (await page.waitForXPath("//span[text()='ICU Bed Usage']/..")).click();
+
+        // Now wait for harris county selector to load
+        (await page.waitForXPath("//div[@aria-label='Harris']")).click();
+
+        /* PowerBI dynamicly swaps out rows so we
+     can't get it all without some scrolling magic
+  */
+        // fill start date  back to beginning
+        // const startDate = await page.waitForXPath("//div[@class='date-slicer']//input[contains(@aria-label, 'Start')]")
+        // await startDate.click({clickCount: 3})
+        // await page.keyboard.type("3/18/2020")
+        // await page.waitFor(1000)
+        // await startDate.press("Enter")
+
+        // use context menu to open table version of chart
+        await (await page.$$('div.visual-lineChart'))[0].click({ button: 'right' });
+        const tableButton = await page.waitForXPath("//drop-down-list-item[//h6[text()='Show as a table']]", {
+          visible: true
+        });
+
+        await page.waitFor(2000);
+        await tableButton.click();
+
+        console.log('I have a table button:', tableButton);
+
+        // Get the data
+        const data = await page.waitForXPath("//div[@aria-label='Grid']").then(getDataFromPivotTable);
+
+        // return now as we don't need the browser anymore
+        return data;
+      };
+
+      const data = await fetch.fetchHeadlessPage(this.url, callback);
+      console.log(data);
+    }
+  }
+};
+
+export default scraper;


### PR DESCRIPTION
## Summary

Adds hopsital and ICU bed usage for harris county TX.

This probably needs a bit more work, but I wanted to touch base with maintainers here to see if I'm on the right direction.

What it does:

- Adds a new export to fetch/index.js that allows users to specify a url and a callback to be called in the context of the opened puppeteer `Page` instance
- Uses the new exported function to open a PowerBI dashbaord from a southeast texas council
- Navigates through that dashboard to a page that contains summary stats on covid patients in general and ICU beds.
- Scrapes this data for Harris county (Houston). There are other counties there that we could scrape, but for now I'm only focusing on Harris county.
- Returns `hospitalized_current` and `icu_current` for `process.env.SCRAPE_DATE`. The scraper has data for previous two weeks, so it is a timeseries


Things I'm a little uncertain on are:

- Is adding this additional exported function to the `fetch`lib ok?
- How could/should we handle cache for this scraper? I'm not sure on the details of how caching is handled here. For now I am completely ignoring it.
- I only return those two current hospital bed usage data points, I don't have more fundamental results like cases, deaths, reported, etc. Those are aggregate level TX scraper. Is there a strategy for merging multiple scraper outputs so we have all the info?

Thanks!