### PR TITLE
Datasf 1011 handle timeseries

### DIFF
--- a/src/shared/lib/maintainers.js
+++ b/src/shared/lib/maintainers.js
@@ -86,6 +86,17 @@ const maintainers = {
     county: 'Ventura County',
     city: 'Ventura',
     flag: '🇺🇸'
+  },
+  '1ec5': {
+    name: 'Minh Nguyễn',
+    url: 'http://notes.1ec5.org/',
+    github: '1ec5',
+    twitter: '1ec5',
+    country: 'USA',
+    state: 'CA',
+    county: 'Santa Clara County',
+    city: 'San José',
+    flag: '🇺🇸'
   }
 };
 

--- a/src/shared/scrapers/US/CA/san-francisco-county.js
+++ b/src/shared/scrapers/US/CA/san-francisco-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import datetime from '../../../lib/datetime/index.js';
 import maintainers from '../../../lib/maintainers.js';
+import * as parse from '../../../lib/parse.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -36,28 +37,68 @@ const scraper = {
     patients: 'https://data.sfgov.org/resource/nxjg-bhem.json',
     tests: 'https://data.sfgov.org/resource/nfpa-mg4g.json'
   },
+  _getScrapeDateString: (proposed, allDates) => {
+    let scrapeDate = proposed;
+    let scrapeDateString = datetime.getYYYYMMDD(new Date(scrapeDate));
+    const firstDateInTimeseries = new Date(allDates[0]);
+    const lastDateInTimeseries = new Date(allDates.slice(-1)[0]);
+
+    if (datetime.scrapeDateIsAfter(lastDateInTimeseries)) {
+      console.error(
+        `  🚨 timeseries for San Francisco County: SCRAPE_DATE ${datetime.getYYYYMMDD(
+          scrapeDate
+        )} is newer than last sample time ${datetime.getYYYYMMDD(lastDateInTimeseries)}. Using last sample anyway`
+      );
+      scrapeDate = lastDateInTimeseries;
+      scrapeDateString = datetime.getYYYYMMDD(scrapeDate);
+    }
+
+    if (datetime.scrapeDateIsBefore(firstDateInTimeseries)) {
+      throw new Error(`Timeseries starts later than SCRAPE_DATE ${datetime.getYYYYMMDD(scrapeDate)}`);
+    }
+    return scrapeDateString;
+  },
   scraper: {
     '0': async function() {
-      const cases = await fetch.json(this, this._urls.cases, 'cases', false);
-      const patients = await fetch.json(this, this._urls.patients, 'patients', false);
-      const tests = await fetch.json(this, this._urls.tests, 'tests', false);
-      const timeSeries = {};
-      cases.reduceRight(
-        (acc, cur) => {
-          const date = datetime.getYYYYMMDD(cur.date);
-          const field = cur.case_disposition === 'Death' ? 'deaths' : 'cases';
-          acc[field] += +cur.case_count;
-          if (!(date in timeSeries)) {
-            timeSeries[date] = {};
-          }
-          timeSeries[date][field] = acc[field];
-          return acc;
-        },
-        {
-          cases: 0,
-          deaths: 0
-        }
-      );
+      function sortBy(fld) {
+        return function(a, b) {
+          if (a[fld] === b[fld]) return 0;
+          return a[fld] < b[fld] ? -1 : 1;
+        };
+      }
+      let cases = await fetch.json(this, this._urls.cases, 'cases', false);
+      cases = cases.sort(sortBy('date'));
+
+      let patients = await fetch.json(this, this._urls.patients, 'patients', false);
+      patients = patients.sort(sortBy('reportdate'));
+
+      let tests = await fetch.json(this, this._urls.tests, 'tests', false);
+      tests = tests.sort(sortBy('result_date'));
+
+      function getCaseField(dt, fld) {
+        const c = cases.filter(cur => dt === datetime.getYYYYMMDD(cur.date) && cur.case_disposition === fld);
+        if (c.length === 0) return 0;
+        return c.reduce((acc, curr) => {
+          return acc + parse.number(curr.case_count);
+        }, 0);
+      }
+
+      function getTestedField(dt) {
+        const c = tests.filter(cur => dt === datetime.getYYYYMMDD(cur.result_date));
+        if (c.length === 0) return 0;
+        return c.reduce((acc, curr) => {
+          return acc + parse.number(curr.tests);
+        }, 0);
+      }
+
+      // I don't _believe_ that hospitalizations are incremental, they
+      // look to be current state.  Per
+      // https://data.sfgov.org/stories/s/wmxr-upyn, the numbers are
+      // below 100.  I also don't know what the different fields in
+      // the raw data set are, and am reluctant to include this data
+      // without understanding it.
+      // TODO (scraper) re-enable hospitalizations when we figure out what the data says.
+      /*
       patients.forEach(elt => {
         const date = datetime.getYYYYMMDD(elt.reportdate);
         if (!(date in timeSeries)) {
@@ -70,21 +111,20 @@ const scraper = {
           timeSeries[date].hospitalized += +elt.patientcount;
         }
       });
-      tests.reduceRight((acc, cur) => {
-        const date = datetime.getYYYYMMDD(cur.result_date);
-        acc += +cur.tests;
-        if (!(date in timeSeries)) {
-          timeSeries[date] = {};
-        }
-        timeSeries[date].tested = acc;
-        return acc;
-      }, 0);
+      */
 
+      const allDates = []
+        .concat(cases.map(c => c.date))
+        .concat(patients.map(p => p.reportdate))
+        .concat(tests.map(t => t.result_date))
+        .sort() // Assuming that all follow same yyyy-mm-dd format!
+        .map(s => s.split('T')[0]);
+
+      // const scrapeDateString = this._getScrapeDateString(datetime.scrapeDate() || new Date(), allDates);
       let scrapeDate = datetime.scrapeDate() || new Date();
       let scrapeDateString = datetime.getYYYYMMDD(new Date(scrapeDate));
-      const datesInTimeseries = Object.keys(timeSeries).sort();
-      const lastDateInTimeseries = new Date(datesInTimeseries.slice(-1)[0]);
-      const firstDateInTimeseries = new Date(datesInTimeseries[0]);
+      const firstDateInTimeseries = new Date(allDates[0]);
+      const lastDateInTimeseries = new Date(allDates.slice(-1)[0]);
 
       if (datetime.scrapeDateIsAfter(lastDateInTimeseries)) {
         console.error(
@@ -100,6 +140,26 @@ const scraper = {
         throw new Error(`Timeseries starts later than SCRAPE_DATE ${datetime.getYYYYMMDD(scrapeDate)}`);
       }
 
+      const timeSeries = {};
+      let runningCases = 0;
+      let runningDeaths = 0;
+      let runningTested = 0;
+      for (let d = firstDateInTimeseries; datetime.getYYYYMMDD(d) <= scrapeDateString; d.setDate(d.getDate() + 1)) {
+        const currYYYYMMDD = datetime.getYYYYMMDD(d);
+
+        runningCases += getCaseField(currYYYYMMDD, 'Confirmed');
+        runningDeaths += getCaseField(currYYYYMMDD, 'Death');
+        runningTested += getTestedField(currYYYYMMDD);
+
+        timeSeries[currYYYYMMDD] = {
+          cases: runningCases,
+          deaths: runningDeaths,
+          // hospitalized: 0,
+          tested: runningTested
+        };
+      }
+
+      // console.table(timeSeries);
       return timeSeries[scrapeDateString];
     }
   }

--- a/src/shared/scrapers/US/CA/san-francisco-county.js
+++ b/src/shared/scrapers/US/CA/san-francisco-county.js
@@ -1,5 +1,5 @@
 import * as fetch from '../../../lib/fetch/index.js';
-import * as parse from '../../../lib/parse.js';
+import datetime from '../../../lib/datetime/index.js';
 import maintainers from '../../../lib/maintainers.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
@@ -9,26 +9,99 @@ const scraper = {
   county: 'San Francisco County',
   state: 'iso2:US-CA',
   country: 'iso1:US',
-  maintainers: [maintainers.jbencina],
-  url: 'https://www.sfdph.org/dph/alerts/coronavirus.asp',
-  type: 'paragraph',
-  async scraper() {
-    let deaths;
-    let cases;
-    const $ = await fetch.page(this, this.url, 'default');
-    const $h2 = $('h2:contains("Cases in San Francisco")');
+  maintainers: [maintainers['1ec5']],
+  type: 'json',
+  timeseries: true,
+  headless: false,
+  sources: [
     {
-      const $p = $h2.nextAll('*:contains("Cases:")');
-      cases = parse.number($p.text());
-    }
+      name: 'San Francisco Department of Public Health',
+      url: 'https://data.sfgov.org/COVID-19/COVID-19-Cases-Summarized-by-Date-Transmission-and/tvq9-ec9w',
+      description: 'COVID-19 Cases Summarized by Date, Transmission and Case Disposition'
+    },
     {
-      const $p = $h2.nextAll('*:contains("Deaths:")');
-      deaths = parse.number($p.text());
+      name: 'San Francisco Department of Public Health',
+      url: 'https://data.sfgov.org/COVID-19/COVID-19-Hospitalizations/nxjg-bhem',
+      description: 'COVID-19 Hospitalizations'
+    },
+    {
+      name: 'San Francisco Department of Public Health',
+      url: 'https://data.sfgov.org/COVID-19/COVID-19-Tests/nfpa-mg4g',
+      description: 'COVID-19 Tests'
     }
-    return {
-      cases,
-      deaths
-    };
+  ],
+  url: 'https://data.sfgov.org/stories/s/dak2-gvuj',
+  _urls: {
+    cases: 'https://data.sfgov.org/resource/tvq9-ec9w.json',
+    patients: 'https://data.sfgov.org/resource/nxjg-bhem.json',
+    tests: 'https://data.sfgov.org/resource/nfpa-mg4g.json'
+  },
+  scraper: {
+    '0': async function() {
+      const cases = await fetch.json(this, this._urls.cases, 'default', false);
+      const patients = await fetch.json(this, this._urls.patients, 'default', false);
+      const tests = await fetch.json(this, this._urls.tests, 'default', false);
+      const timeSeries = {};
+      cases.reduceRight(
+        (acc, cur) => {
+          const date = datetime.getYYYYMMDD(cur.date);
+          const field = cur.case_disposition === 'Death' ? 'deaths' : 'cases';
+          acc[field] += +cur.case_count;
+          if (!(date in timeSeries)) {
+            timeSeries[date] = {};
+          }
+          timeSeries[date][field] = acc[field];
+          return acc;
+        },
+        {
+          cases: 0,
+          deaths: 0
+        }
+      );
+      patients.forEach(elt => {
+        const date = datetime.getYYYYMMDD(elt.reportdate);
+        if (!(date in timeSeries)) {
+          timeSeries[date] = {};
+        }
+        if (elt.patientcount) {
+          if (!('hospitalized' in timeSeries[date])) {
+            timeSeries[date].hospitalized = 0;
+          }
+          timeSeries[date].hospitalized += +elt.patientcount;
+        }
+      });
+      tests.reduceRight((acc, cur) => {
+        const date = datetime.getYYYYMMDD(cur.result_date);
+        acc += +cur.tests;
+        if (!(date in timeSeries)) {
+          timeSeries[date] = {};
+        }
+        timeSeries[date].tested = acc;
+        return acc;
+      }, 0);
+
+      let scrapeDate = datetime.scrapeDate() || new Date();
+      let scrapeDateString = datetime.getYYYYMMDD(new Date(scrapeDate));
+      const datesInTimeseries = Object.keys(timeSeries).sort();
+      const lastDateInTimeseries = new Date(datesInTimeseries.slice(-1)[0]);
+      const firstDateInTimeseries = new Date(datesInTimeseries[0]);
+
+      if (datetime.scrapeDateIsAfter(lastDateInTimeseries)) {
+        console.error(
+          `  🚨 timeseries for San Francisco County: SCRAPE_DATE ${datetime.getYYYYMMDD(
+            scrapeDate
+          )} is newer than last sample time ${datetime.getYYYYMMDD(lastDateInTimeseries)}. Using last sample anyway`
+        );
+        scrapeDate = lastDateInTimeseries;
+        scrapeDateString = datetime.getYYYYMMDD(scrapeDate);
+      }
+
+      if (datetime.scrapeDateIsBefore(firstDateInTimeseries)) {
+        throw new Error(`Timeseries starts later than SCRAPE_DATE ${datetime.getYYYYMMDD(scrapeDate)}`);
+      }
+
+      return timeSeries[scrapeDateString];
+    }
   }
 };
 

--- a/src/shared/scrapers/US/CA/san-francisco-county.js
+++ b/src/shared/scrapers/US/CA/san-francisco-county.js
@@ -38,9 +38,9 @@ const scraper = {
   },
   scraper: {
     '0': async function() {
-      const cases = await fetch.json(this, this._urls.cases, 'default', false);
-      const patients = await fetch.json(this, this._urls.patients, 'default', false);
-      const tests = await fetch.json(this, this._urls.tests, 'default', false);
+      const cases = await fetch.json(this, this._urls.cases, 'cases', false);
+      const patients = await fetch.json(this, this._urls.patients, 'patients', false);
+      const tests = await fetch.json(this, this._urls.tests, 'tests', false);
       const timeSeries = {};
       cases.reduceRight(
         (acc, cur) => {


### PR DESCRIPTION
Completes the work of @1ec5, branch datasf-1011.

The numbers match https://data.sfgov.org/stories/s/fjki-2fab.

![image](https://user-images.githubusercontent.com/1637133/83341446-9f13af80-a2b1-11ea-9671-ab1e16e09bf1.png)

vs this PR:

```
$ yarn start --location US/CA/san-francisco-county.js
...
 Total counts (tracked cases, may contain duplicates):
   - 2325 cases
   - 50554 tested
   - 0 recovered
   - 40 deaths
   - 0 active

```

I didn't include hospitalizations, as I didn't really trust the data.