### PR TITLE
San Francisco renamed its date fields

### DIFF
--- a/src/shared/scrapers/US/CA/san-francisco-county.js
+++ b/src/shared/scrapers/US/CA/san-francisco-county.js
@@ -65,16 +65,18 @@ const scraper = {
         };
       }
       let cases = await fetch.json(this, this._urls.cases, 'cases', false);
-      cases = cases.sort(sortBy('date'));
+      cases = cases.sort(sortBy('specimen_collection_date'));
 
       let patients = await fetch.json(this, this._urls.patients, 'patients', false);
       patients = patients.sort(sortBy('reportdate'));
 
       let tests = await fetch.json(this, this._urls.tests, 'tests', false);
-      tests = tests.sort(sortBy('result_date'));
+      tests = tests.sort(sortBy('specimen_collection_date'));
 
       function getCaseField(dt, fld) {
-        const c = cases.filter(cur => dt === datetime.getYYYYMMDD(cur.date) && cur.case_disposition === fld);
+        const c = cases.filter(
+          cur => dt === datetime.getYYYYMMDD(cur.specimen_collection_date) && cur.case_disposition === fld
+        );
         if (c.length === 0) return 0;
         return c.reduce((acc, curr) => {
           return acc + parse.number(curr.case_count);
@@ -82,7 +84,7 @@ const scraper = {
       }
 
       function getTestedField(dt) {
-        const c = tests.filter(cur => dt === datetime.getYYYYMMDD(cur.result_date));
+        const c = tests.filter(cur => dt === datetime.getYYYYMMDD(cur.specimen_collection_date));
         if (c.length === 0) return 0;
         return c.reduce((acc, curr) => {
           return acc + parse.number(curr.tests);
@@ -112,9 +114,9 @@ const scraper = {
       */
 
       const allDates = []
-        .concat(cases.map(c => c.date))
+        .concat(cases.map(c => c.specimen_collection_date))
         .concat(patients.map(p => p.reportdate))
-        .concat(tests.map(t => t.result_date))
+        .concat(tests.map(t => t.specimen_collection_date))
         .sort() // Assuming that all follow same yyyy-mm-dd format!
         .map(s => s.split('T')[0]);
       const [firstDate, scrapeDate] = this._getScrapeDateBounds(datetime.scrapeDate() || new Date(), allDates);


### PR DESCRIPTION
San Francisco renamed its date fields to emphasize that these data points are based on the date of specimen collection rather than the date reported.

<!--
Hello!

This project is being replaced by Li, https://github.com/covidatlas/li, the next-generation serverless crawler for COVID-19 data.  The reasons for the switchover are documented in https://github.com/covidatlas/coronadatascraper/issues/782.

We are not _actively_ accepting PRs for this repository.

Note: Scraper code written for this project is not compatible with Li, see that project for examples.  We have some helpers to assist in migrating code, see [this document](https://docs.google.com/document/d/1ITPU0hESswmiWw88Pl1eI26oIQtMJw1YUeD8mWEPIeE/edit#).

Thanks very much!
-->


<!---
Hi there!  Some things to double-check prior to submission:

- did you recently update this branch with upstream master,
  to ensure everything works together?
- did you `yarn lint` ?
- did you `yarn test` ?
- have you added any new tape tests to verify your change?
- did you update any relevant documentation?
-->

## Summary

<!-- What is this change about?  If it's related to an issue, please include the issue number (e.g., #426) -->

<!-- Short description, before this change ... -->

<!-- Short description, after this change ... -->

## Changes

<!-- Short summary of the code.  List major points, and refer to the lines in the diff as needed. -->

## Additional notes

<!--
  * mention any test coverage added or changed
  * what are success/failure conditions?
  * are there any side effects?
-->

<!-- Erase any parts of this template if they're not applicable.  Cheers! -->
