### PR TITLE
Replace cds dist reports with li s3 reports

### DIFF
--- a/covidatlas/location-graph.js
+++ b/covidatlas/location-graph.js
@@ -130,7 +130,7 @@ const showGraph = ({ timeseries, location }) => {
   const locationData = Object.keys(timeseries).map(date => {
     return {
       date,
-      ...timeseries[date][location.id]
+      ...timeseries[date][`${location.id}`]
     };
   });
 

--- a/package.json
+++ b/package.json
@@ -21,14 +21,20 @@
     "publishSite": "npm run buildSite && gh-pages -a -d dist/ -e .",
     "lint": "eslint .",
     "options": "node -r esm src/shared/cli/cli-args.js -h",
-    "start": "node src/shared/cli/index.js",
+
+    "start": "echo === DISABLED === && echo Run 'yarn timeseries' to pull down reports from Li. && echo Use 'yarn start-old' to run CDS scrapers.",
+    "start-old": "node src/shared/cli/index.js",
+
     "qa": "pta ./src/qa/*.qa.js -r log | node src/qa/utils/qa-reporter.js",
     "test": "tape tests/**/*-test.js | tap-spec",
     "test:unit": "tape tests/unit/**/*-test.js | tap-spec",
     "test:integration": "tape tests/integration/**/*-test.js | tap-spec",
     "test:watch": "tape-watch tests/**/*-test.js -p tap-spec",
     "test:tz": "tape scripts/test-timezones.js | tap-spec",
-    "timeseries": "node src/shared/timeseries/index.js",
+
+    "timeseries": "echo === DISABLED === && echo Downloading Li reports s3 instead && echo Use yarn timeseries-old to run old scripts. && echo && scripts/download-li-s3-reports-to-dist.sh",
+    "timeseries-old": "node src/shared/timeseries/index.js",
+
     "update": "npm run updateModules && rm -rf cache/* && npm run start",
     "updateModules": "git submodule update --remote",
     "pretty": "prettier --write '**/*.js'"

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
   "scripts": {
     "devcovidatlas": "npx arc sandbox & npx rollup -c covidatlas.rollup.config.js --watch",
     "buildcovidatlas": "npx rollup -c covidatlas.rollup.config.js",
+
     "dev": "npx rollup -c --watch",
     "build": "npx yarn start && npx yarn timeseries && npx yarn buildSite",
     "buildSite": "npx rollup -c",
-    "dateData": "DATE=$(date +'%Y-%m-%d') && cp dist/data.json dist/data-$DATE.json && cp dist/features.json dist/features-$DATE.json && cp dist/data.csv dist/data-$DATE.csv",
+    "dateData": "DATE=$(date +'%Y-%m-%d') && cp dist/latest.json dist/latest-$DATE.json && cp dist/features.json dist/features-$DATE.json && cp dist/latest.csv dist/latest-$DATE.csv",
     "deploy": "npm run dateData && npm run deploySite",
-    "deploySite": "cd dist && zip -r timeseries-tidy.csv.zip timeseries-tidy.csv && rm timeseries-tidy.csv && cd .. && yarn publishSite",
+    "deploySite": "yarn publishSite",
     "publishSite": "npm run buildSite && gh-pages -a -d dist/ -e .",
     "lint": "eslint .",
     "options": "node -r esm src/shared/cli/cli-args.js -h",
@@ -32,8 +33,7 @@
     "test:watch": "tape-watch tests/**/*-test.js -p tap-spec",
     "test:tz": "tape scripts/test-timezones.js | tap-spec",
 
-    "timeseries": "echo === DISABLED === && echo Use 'yarn timeseries-li' to download Li S3 reports to dist && echo Use 'yarn timeseries-old' to run old scripts",
-    "timeseries-li": "echo && scripts/download-li-s3-reports-to-dist.sh",
+    "timeseries": "echo && scripts/download-li-s3-reports-to-dist.sh",
     "timeseries-old": "node src/shared/timeseries/index.js",
 
     "update": "npm run updateModules && rm -rf cache/* && npm run start",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint .",
     "options": "node -r esm src/shared/cli/cli-args.js -h",
 
-    "start": "echo === DISABLED === && echo Run 'yarn timeseries' to pull down reports from Li. && echo Use 'yarn start-old' to run CDS scrapers.",
+    "start": "echo === DISABLED === && echo Use 'yarn timeseries-li' to pull down reports from Li. && echo Use 'yarn start-old' to run CDS scrapers.",
     "start-old": "node src/shared/cli/index.js",
 
     "qa": "pta ./src/qa/*.qa.js -r log | node src/qa/utils/qa-reporter.js",
@@ -32,7 +32,8 @@
     "test:watch": "tape-watch tests/**/*-test.js -p tap-spec",
     "test:tz": "tape scripts/test-timezones.js | tap-spec",
 
-    "timeseries": "echo === DISABLED === && echo Downloading Li reports s3 instead && echo Use yarn timeseries-old to run old scripts. && echo && scripts/download-li-s3-reports-to-dist.sh",
+    "timeseries": "echo === DISABLED === && echo Use 'yarn timeseries-li' to download Li S3 reports to dist && echo Use 'yarn timeseries-old' to run old scripts",
+    "timeseries-li": "echo && scripts/download-li-s3-reports-to-dist.sh",
     "timeseries-old": "node src/shared/timeseries/index.js",
 
     "update": "npm run updateModules && rm -rf cache/* && npm run start",

--- a/scripts/download-li-s3-reports-to-dist.sh
+++ b/scripts/download-li-s3-reports-to-dist.sh
@@ -8,7 +8,6 @@
 # moment Li doesn't create a corresponding file.
 
 echo 'Replacing existing reports in dist with all reports downloaded from li s3.'
-echo "Note: paths are HARD-CODED to staging buckets currently!"
 echo
 
 # Bucket names pulled from Li aws.
@@ -19,11 +18,11 @@ rm -rf dist
 mkdir -p dist
 pushd dist
 
-bucketName="$stagingBucket"
+bucketName="$productionBucket"
 key=v1/latest
 
 echo "pulling files from ${bucketName}/${key}"
-for f in timeseries.json features.json locations.json; do
+for f in latest.csv latest.json timeseries.json features.json locations.json timeseries-byLocation.json timeseries.csv timeseries-jhu.csv; do
     echo "  $f"
     aws --no-sign-request --region=us-west-1 s3 cp s3://${bucketName}/${key}/${f} .
 done

--- a/scripts/download-li-s3-reports-to-dist.sh
+++ b/scripts/download-li-s3-reports-to-dist.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+#
+# Run this from project root.
+
+echo 'Replacing existing reports in dist with all reports downloaded from li s3.'
+echo "Note: paths are HARD-CODED to staging buckets currently!"
+echo
+
+# Bucket names pulled from Li aws.
+stagingBucket=listaging-reportsbucket-1bjqfmfwopcdd
+productionBucket=liproduction-reportsbucket-bhk8fnhv1s76
+
+rm -rf dist
+mkdir -p dist
+pushd dist
+
+bucketName="$stagingBucket"
+key=v1/latest
+
+echo "pulling files from ${bucketName}/${key}"
+aws --no-sign-request --region=us-west-1 s3 cp s3://${bucketName}/${key} . --recursive
+
+popd
+ls -1 dist
+
+echo
+echo "done."

--- a/scripts/download-li-s3-reports-to-dist.sh
+++ b/scripts/download-li-s3-reports-to-dist.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 #
 # Run this from project root.
+#
+# This script pulls down the files referenced in src/macros/build.sh:
+# timeseries.json, features.json, locations.json.  It creates fake
+# placeholder files for report.json and ratings.json, because at the
+# moment Li doesn't create a corresponding file.
 
 echo 'Replacing existing reports in dist with all reports downloaded from li s3.'
 echo "Note: paths are HARD-CODED to staging buckets currently!"
@@ -18,7 +23,14 @@ bucketName="$stagingBucket"
 key=v1/latest
 
 echo "pulling files from ${bucketName}/${key}"
-aws --no-sign-request --region=us-west-1 s3 cp s3://${bucketName}/${key} . --recursive
+for f in timeseries.json features.json locations.json; do
+    echo "  $f"
+    aws --no-sign-request --region=us-west-1 s3 cp s3://${bucketName}/${key}/${f} .
+done
+
+echo "Creating stub files for missing reports:"
+echo {} > report.json
+echo [] > ratings.json
 
 popd
 ls -1 dist

--- a/site/index.html
+++ b/site/index.html
@@ -75,8 +75,8 @@
               <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" href="#sources">Sources</a></li>
               <li class="spectrum-SideNav-item"><div class="spectrum-SideNav-itemLink" href="#">Today's data</div>
                 <ul class="spectrum-SideNav spectrum-SideNav--multiLevel">
-                  <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="data.csv"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> CSV</a></li>
-                  <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="data.json"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> JSON</a></li>
+                  <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="latest.csv"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> CSV</a></li>
+                  <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="latest.json"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> JSON</a></li>
                 </ul>
               </li>
               <li class="spectrum-SideNav-item"><div class="spectrum-SideNav-itemLink" href="#">Timeseries</div>
@@ -84,19 +84,17 @@
                   <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="timeseries.json"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> JSON (by date)</a></li>
                   <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="timeseries-byLocation.json"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> JSON (by location)</a></li>
                   <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="timeseries.csv"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> CSV</a></li>
-                  <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download data-noview href="timeseries-tidy.csv.zip"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> CSV (Tidy format)</a></li>
                   <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="timeseries-jhu.csv"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> CSV (like JHU)</a></li>
                 </ul>
               </li>
               <li class="spectrum-SideNav-item"><div class="spectrum-SideNav-itemLink" href="#">Metadata</div>
                 <ul class="spectrum-SideNav spectrum-SideNav--multiLevel">
                   <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="locations.json"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> Location Metadata</a></li>
-                  <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" download href="report.json" data-levels="2"><span class="spectrum-SideNav-itemIcon icon icon-file"></span> Scrape Report</a></li>
                 </ul>
               </li>
               <!-- <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" href="https://blog.lazd.net/coronaglobe" target="_blank">View on 3D map (Coronaglobe)</a></li> -->
-              <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" href="https://github.com/lazd/coronadatascraper/" target="_blank" rel="noopener">Github</a></li>
-              <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" href="https://github.com/lazd/coronadatascraper/issues/new" target="_blank" rel="noopener">Report Issue</a></li>
+              <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" href="https://github.com/covidatlas/li/" target="_blank" rel="noopener">Github</a></li>
+              <li class="spectrum-SideNav-item"><a class="spectrum-SideNav-itemLink" href="https://github.com/covidatlas/li/issues/new" target="_blank" rel="noopener">Report Issue</a></li>
             </ul>
           </nav>
         </div>

--- a/src/http/get-000location/index.js
+++ b/src/http/get-000location/index.js
@@ -55,9 +55,14 @@ function locationDetail(location, lastDate, caseInfo, rating, crosscheckReport) 
   html += `<div class="row">
     <div class="col-xs-12 col-sm-6">`;
   html += `<p class="spectrum-Body spectrum-Body--XS ca-LocationMeta">Updated: ${lastDate}</p>`;
+
+  // TODO (covidatlas) Determine what to use for single contributor link
+  /*
   html += `<p class="spectrum-Body spectrum-Body--XS ca-LocationMeta">Data from ${getSingleContributorLink(
     location
   )}</p>`;
+  */
+
   html += `</div>
     <div class="col-xs-12 col-sm-6 end-sm">
       <!-- todo: make this responsive, dropdown menu on mobile -->
@@ -123,14 +128,18 @@ function locationDetail(location, lastDate, caseInfo, rating, crosscheckReport) 
   <div class="row">
 `;
 
-  html += `
+  // TODO (covidatlas) rating temporarily disabled.
+  if (rating) {
+    html += `
     <section class="ca-SubSection col-xs-12 col-sm-6 col-md-4">
       <h4 class="spectrum-Heading spectrum-Heading--S">Data source rating</h4>
       <p class="spectrum-Body spectrum-Body--S">Our <a class="spectrum-Link" href="/sources">data transparency rating</a> is based on the granularity, completeness, and technical format of this data source.</p>
       ${ratingTemplate(rating)}
     </section>
 `;
+  }
 
+  // TODO (covidatlas) crosscheckReport temporarily disabled.
   if (crosscheckReport) {
     html += `
       <section class="ca-SubSection col-xs-12 col-sm-6 col-md-8">
@@ -175,6 +184,7 @@ function locationDetail(location, lastDate, caseInfo, rating, crosscheckReport) 
   return html;
 }
 
+// eslint-disable-next-line
 function locationMatches(a, b) {
   return a.country === b.country && a.state === b.state && a.county === b.county && a.city === b.city;
 }
@@ -192,8 +202,13 @@ async function route(req) {
   location.slug = slug;
   parentLocation.slug = getSlug(parentLocation);
 
-  const rating = ratings.find(rating => location.url === rating.url);
-  const crosscheckReport = report.scrape.crosscheckReports.find(report => locationMatches(location, report.location));
+  // TODO (covidatlas) disabling rating until we determine what to do.
+  // const rating = ratings.find(rating => location.url === rating.url);
+  const rating = null;
+
+  // TODO (covidatlas) disabling crosscheckReport until we determine what to do.
+  // const crosscheckReport = report.scrape.crosscheckReports.find(report => locationMatches(location, report.location));
+  const crosscheckReport = null;
 
   // Display the information for the location
   return {

--- a/src/http/get-000location/index.js
+++ b/src/http/get-000location/index.js
@@ -11,7 +11,7 @@ const footer = require('@architect/views/footer');
 const sidebar = require('@architect/views/sidebar');
 
 // eslint-disable-next-line
-const { levels, getName, getSlug, getParentLocation } = require('@architect/views/lib/geography');
+const { levels, getName, getParentLocation } = require('@architect/views/lib/geography');
 // eslint-disable-next-line
 const { getContributors, getSingleContributorLink } = require('@architect/views/lib/contributors');
 // eslint-disable-next-line
@@ -36,7 +36,7 @@ function renderBreadcrumbs(location) {
   for (const level of levels.slice().reverse()) {
     if (location[level]) {
       obj[level] = location[level];
-      htmlBits.push(`<a class="spectrum-Link spectrum-Link--silent" href="${getSlug(obj)}">${location[level]}</a>`);
+      htmlBits.push(`<a class="spectrum-Link spectrum-Link--silent" href="${obj[level].slug}">${location[level]}</a>`);
     }
   }
   return htmlBits.reverse().join(', ');
@@ -186,21 +186,17 @@ function locationDetail(location, lastDate, caseInfo, rating, crosscheckReport) 
 
 // eslint-disable-next-line
 function locationMatches(a, b) {
-  return a.country === b.country && a.state === b.state && a.county === b.county && a.city === b.city;
+  return a.locationID === b.locationID;
 }
 
 async function route(req) {
   // Get latest information from timeseries
-  const { location, slug } = req;
+  const { location } = req;
   const lastDate = Object.keys(timeseries).pop();
   const caseInfo = timeseries[lastDate][location.id];
 
   // Get parent location
   const parentLocation = getParentLocation(location, locationMap) || location;
-
-  // Add slugs
-  location.slug = slug;
-  parentLocation.slug = getSlug(parentLocation);
 
   // TODO (covidatlas) disabling rating until we determine what to do.
   // const rating = ratings.find(rating => location.url === rating.url);

--- a/src/http/get-000location/index.js
+++ b/src/http/get-000location/index.js
@@ -118,17 +118,20 @@ function locationDetail(location, lastDate, caseInfo, rating, crosscheckReport) 
         </div>
       </div>
     </div>
-  </div>
-  <div class="row">
+  </div>`;
+
+  // TODO (covidatlas) map temporarily disabled during cutover to Li.
+  html += `<div class="row">
     <div class="col-xs-12 col-md-12">
-      <h2 class="spectrum-Heading spectrum-Heading--M">Regional map</h1>
-      <div id="map" class="ca-Map"></div>
+      <!--  DISABLED, leaving outer div b/c page layout is messed up without it.
+        <h2 class="spectrum-Heading spectrum-Heading--M">Regional map</h1>
+        <div id="map" class="ca-Map"></div>
+      -->
     </div>
   </div>
-  <div class="row">
-`;
+  <div class="row">`;
 
-  // TODO (covidatlas) rating temporarily disabled.
+  // TODO (covidatlas) rating temporarily disabled during cutover to Li.
   if (rating) {
     html += `
     <section class="ca-SubSection col-xs-12 col-sm-6 col-md-4">
@@ -139,7 +142,7 @@ function locationDetail(location, lastDate, caseInfo, rating, crosscheckReport) 
 `;
   }
 
-  // TODO (covidatlas) crosscheckReport temporarily disabled.
+  // TODO (covidatlas) crosscheckReport temporarily disabled during cutover to Li.
   if (crosscheckReport) {
     html += `
       <section class="ca-SubSection col-xs-12 col-sm-6 col-md-8">

--- a/src/http/get-api-features-000location/index.js
+++ b/src/http/get-api-features-000location/index.js
@@ -13,8 +13,7 @@ const { getChildLocations } = require('@architect/views/lib/geography');
 
 async function route(req) {
   const { location } = req;
-  const level = req.queryStringParameters.level || location.level;
-  const childLocations = getChildLocations(location, Object.values(locationMap), level);
+  const childLocations = getChildLocations(location, Object.values(locationMap));
   const subFeatureCollection = filterFeatureCollectionByLocations(featureCollection, childLocations);
 
   return {

--- a/src/http/get-api-locations-000location/index.js
+++ b/src/http/get-api-locations-000location/index.js
@@ -10,15 +10,14 @@ const { getChildLocations } = require('@architect/views/lib/geography');
 
 async function route(req) {
   const { location } = req;
-  const level = req.queryStringParameters.level || location.level;
-  const childLocations = getChildLocations(location, locationMap, level);
-
+  const childLocations = getChildLocations(location, locationMap);
+  const allLocations = childLocations.concat(location);
   return {
     headers: {
       'cache-control': 'no-cache, no-store, must-revalidate, max-age=0, s-maxage=0',
       'content-type': 'application/json; charset=utf8'
     },
-    body: JSON.stringify(childLocations)
+    body: JSON.stringify(allLocations)
   };
 }
 

--- a/src/http/get-api-timeseries-000location/index.js
+++ b/src/http/get-api-timeseries-000location/index.js
@@ -14,9 +14,7 @@ const { getChildLocations } = require('@architect/views/lib/geography');
 
 async function route(req) {
   const { location } = req;
-  const level = req.queryStringParameters.level || location.level;
-  const childLocations = getChildLocations(location, Object.values(locations), level);
-  const subTimeseries = filterTimeseriesByLocations(timeseries, childLocations);
+  const subTimeseries = filterTimeseriesByLocations(timeseries, location);
 
   return {
     headers: {

--- a/src/http/get-data/index.js
+++ b/src/http/get-data/index.js
@@ -10,7 +10,22 @@ const footer = require('@architect/views/footer');
 const sidebar = require('@architect/views/sidebar');
 
 exports.handler = async function http() {
-  const baseURL = 'https://coronadatascraper.com/';
+  function rptLink(report) {
+    const baseURL = 'https://liproduction-reportsbucket-bhk8fnhv1s76.s3-us-west-1.amazonaws.com/v1/latest';
+    const href = `${baseURL}/${report}`;
+    return `<li><a href="${href}" target="_blank">${report}</a></li>`;
+  }
+
+  const latestLinks = ['latest.json', 'latest.csv'].map(rptLink).join('');
+  const timeseriesLinks = [
+    'timeseries-byLocation.json',
+    'timeseries-jhu.csv',
+    'timeseries-tidy-small.csv',
+    'timeseries.csv'
+  ]
+    .map(rptLink)
+    .join('');
+  const locationLinks = ['locations.json', 'locations.csv', 'features.json'].map(rptLink).join('');
 
   return {
     headers: {
@@ -33,51 +48,40 @@ ${header('data' /* 'ca-SiteHeader--dark spectrum--dark' */)}
       <p class="spectrum-Body spectrum-Body--L">COVID Atlas data is de-duplicated, cross-checked against other sources, and annotated with population data and GeoJSON features. Currently, COVID Atlas crawls and aggregates data from over 150 sources, <strong>covering more 500 states and regions, 3000 counties, and municipalities, and 190 countries</strong>.</p>
       <p class="spectrum-Body spectrum-Body--L">The consolidated, multi-format dataset of granular COVID-19 case information is available in the public domain for anyone to view, download, or access via an API.</p>
       <p class="spectrum-Body spectrum-Body--L">We encourage scientists, researchers, developers, journalists, and anyone else to analyze this dataset, use it to create models and projections, create visualizations, or identify errors and missing data.</p>
-    </div>
-
-    <hr>
 
     <div class="ca-Section row">
-      <section class="ca-SubSection col-xs-12 col-sm-6 col-md-4">
-        <h1 class="spectrum-Heading spectrum-Heading--M">Global timeseries</h1>
-        <p class="spectrum-Body spectrum-Body--M">Worldwide COVID-19 data in timeseries format (starting at 2020-01-22)</p>
-        <!-- <sp-button variant="primary" quiet href="#notimplemented">View data</sp-button> -->
-
-        <overlay-trigger id="trigger" placement="bottom" class="ca-DownloadTrigger">
-          <sp-button variant="primary" slot="trigger">Download</sp-button>
-          <sp-popover dialog slot="click-content" tip open class="ca-DownloadPopover" direction="bottom">
-            <sp-menu>
-              <sp-menu-item download target="_blank" href="${baseURL}timeseries.csv">CSV</sp-menu-item>
-              <sp-menu-item download target="_blank" href="${baseURL}timeseries.json">JSON</sp-menu-item>
-              <sp-menu-item download target="_blank" href="${baseURL}timeseries-byLocation.json">JSON (by location)</sp-menu-item>
-            </sp-menu>
-          </sp-popover>
-        </overlay-trigger>
-      </section>
 
       <section class="ca-SubSection col-xs-12 col-sm-6 col-md-4">
-        <h1 class="spectrum-Heading spectrum-Heading--M">Global daily totals</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--M">Latest: Global daily totals</h1>
         <p class="spectrum-Body spectrum-Body--M">A point-in-time snapshot of worldwide COVID-19 data (updated daily)</p>
-        <!-- <sp-button variant="primary" quiet href="#notimplemented">View data</sp-button> -->
-        </sp-dropdown>
-        <overlay-trigger id="trigger" placement="bottom" class="ca-DownloadTrigger">
-          <sp-button variant="primary" slot="trigger">Download</sp-button>
-          <sp-popover dialog slot="click-content" tip open class="ca-DownloadPopover" direction="bottom">
-          <sp-menu>
-            <sp-menu-item download target="_blank" href="${baseURL}data.csv">CSV</sp-menu-item>
-            <sp-menu-item download target="_blank" href="${baseURL}data.json">JSON</sp-menu-item>
-          </sp-menu>
-          </sp-popover>
-        </overlay-trigger>
       </section>
 
       <section class="ca-SubSection col-xs-12 col-sm-6 col-md-4">
-        <h1 class="spectrum-Heading spectrum-Heading--M">GeoJSON features</h1>
+        <h1 class="spectrum-Heading spectrum-Heading--M">Timeseries: Global timeseries</h1>
+        <p class="spectrum-Body spectrum-Body--M">Worldwide COVID-19 data in timeseries format (starting at 2020-01-22)</p>
+      </section>
+
+      <section class="ca-SubSection col-xs-12 col-sm-6 col-md-4">
+        <h1 class="spectrum-Heading spectrum-Heading--M">Locations: Metadata and GeoJSON features</h1>
         <p class="spectrum-Body spectrum-Body--M">GeoJSON features for all locations found in our dataset, useful for building map visualizations</p>
-        <!-- <sp-button variant="primary" quiet href="/map">View map</sp-button> -->
-        <sp-button emphasized href="${baseURL}features.json" target="_blank" download>Download</sp-button>
       </section>
     </div>
+
+      <hr>
+
+      <p class="spectrum-Body spectrum-Body--M">Documentation for the reports is available <a href="https://github.com/covidatlas/li/blob/master/docs/reports-v1.md">on GitHub.</a></p>
+
+      <h1>V1</h1>
+
+<h2>Latest</h2>
+<ul>${latestLinks}</ul>
+<h2>Timeseries</h2>
+<ul>${timeseriesLinks}</ul>
+<h2>Locations</h2>
+<ul>${locationLinks}</ul>
+
+</div>
+
     ${footer()}
   </div>
 </div>

--- a/src/macros/build.js
+++ b/src/macros/build.js
@@ -2,58 +2,53 @@ const imports = require('esm')(module);
 
 const lunr = imports('lunr');
 const fs = imports('../shared/lib/fs.js');
-const geography = imports('../views/lib/geography.js');
+
+function locationFullName(location) {
+  const parts = [location.cityName, location.countyName, location.stateName, location.countryName];
+  return parts.filter(s => s).join(', ');
+}
 
 function buildLocationMap(locations) {
   const locationMap = {};
-  for (const [id, location] of Object.entries(locations)) {
-    const shortName = geography.getSlug(location);
-    location.id = id;
-    locationMap[shortName] = location;
-  }
+  locations.forEach((location, index) => {
+    location.id = index;
+    location.name = locationFullName(location);
+    locationMap[location.slug] = location;
+  });
   return locationMap;
-}
-
-function getBarebonesLocation(location) {
-  return {
-    name: location.name
-  };
 }
 
 function buildBarebonesLocationMap(locations) {
   const locationMap = {};
-
-  for (const [id, location] of Object.entries(locations)) {
-    locationMap[geography.getSlug(location)] = {
-      id,
-      ...getBarebonesLocation(location)
+  locations.forEach((location, index) => {
+    locationMap[location.slug] = {
+      id: index,
+      name: locationFullName(location)
     };
-  }
-
+  });
   return locationMap;
 }
 
 function getSkinnyLocation(location) {
   return {
-    name: location.name,
+    name: locationFullName(location),
     level: location.level,
-    city: location.city,
-    county: location.county,
-    state: location.state,
-    country: location.country,
-    featureId: location.featureId
+    city: location.cityName,
+    county: location.countyName,
+    state: location.stateName,
+    country: location.countryName,
+    featureId: location.locationID
   };
 }
 
 function buildSkinnyLocationMap(locations) {
   const locationMap = {};
-
-  for (const [id, location] of Object.entries(locations)) {
-    locationMap[geography.getSlug(location)] = {
-      id,
+  locations.forEach((location, index) => {
+    locationMap[location.slug] = {
+      id: index,
       ...getSkinnyLocation(location)
     };
-  }
+  });
 
   return locationMap;
 }
@@ -62,12 +57,9 @@ async function buildIndex(locations) {
   const index = lunr(function() {
     this.ref('slug');
     this.field('name');
-
     locations.forEach(function(location) {
-      const slug = geography.getSlug(location);
-
       this.add({
-        slug,
+        slug: location.slug,
         ...getSkinnyLocation(location)
       });
     }, this);

--- a/src/macros/build.js
+++ b/src/macros/build.js
@@ -23,6 +23,7 @@ function buildBarebonesLocationMap(locations) {
   locations.forEach((location, index) => {
     locationMap[location.slug] = {
       id: index,
+      locationID: location.locationID,
       name: locationFullName(location)
     };
   });
@@ -37,7 +38,7 @@ function getSkinnyLocation(location) {
     county: location.countyName,
     state: location.stateName,
     country: location.countryName,
-    featureId: location.locationID
+    locationID: location.locationID
   };
 }
 

--- a/src/macros/build.js
+++ b/src/macros/build.js
@@ -13,6 +13,7 @@ function buildLocationMap(locations) {
   locations.forEach((location, index) => {
     location.id = index;
     location.name = locationFullName(location);
+    location.featureID = location.locationID;
     locationMap[location.slug] = location;
   });
   return locationMap;
@@ -24,6 +25,7 @@ function buildBarebonesLocationMap(locations) {
     locationMap[location.slug] = {
       id: index,
       locationID: location.locationID,
+      featureID: location.locationID,
       name: locationFullName(location)
     };
   });
@@ -38,6 +40,7 @@ function getSkinnyLocation(location) {
     county: location.countyName,
     state: location.stateName,
     country: location.countryName,
+    featureID: location.locationID,
     locationID: location.locationID
   };
 }

--- a/src/views/constants.js
+++ b/src/views/constants.js
@@ -4,9 +4,9 @@ const prod = process.env.NODE_ENV === 'production';
 
 module.exports = {
   name: 'COVID Atlas',
-  repoURL: 'https://github.com/covidatlas/coronadatascraper/',
+  repoURL: 'https://github.com/covidatlas/li/',
   slackURL: 'https://join.slack.com/t/covid-atlas/shared_invite/zt-d6j8q1lw-C4t00WbmIjoxeHgxn_GDPQ',
-  issueURL: 'https://github.com/covidatlas/coronadatascraper/issues/new/choose',
+  issueURL: 'https://github.com/covidatlas/li/issues/new/choose',
   analyticsCode: prod ? 'UA-166126663-1' : 'UA-166126663-2',
   prod,
   disclaimer

--- a/src/views/lib/features.js
+++ b/src/views/lib/features.js
@@ -1,6 +1,6 @@
-const findFeature = (module.exports.findFeature = function(featureCollection, id) {
-  return featureCollection.features.find(feature => feature.properties.id === id);
-});
+module.exports.findFeature = function(featureCollection, locationID) {
+  return featureCollection[locationID];
+};
 
 module.exports.filterFeatureCollectionByLocations = function(featureCollection, locations) {
   if (!Array.isArray(locations)) {
@@ -9,6 +9,6 @@ module.exports.filterFeatureCollectionByLocations = function(featureCollection, 
 
   return {
     type: 'FeatureCollection',
-    features: locations.map(location => findFeature(featureCollection, location.featureId)).filter(Boolean)
+    features: locations.map(location => featureCollection[location.locationID])
   };
 };

--- a/src/views/lib/geography.js
+++ b/src/views/lib/geography.js
@@ -40,7 +40,7 @@ module.exports.getLocationGranularityName = function(location) {
 
 const getChildLocations = (module.exports.getChildLocations = function(location, locations) {
   // Find all its children
-  return locations
+  return Object.values(locations)
     .filter(loc => loc.locationID !== location.locationID)
     .filter(loc => loc.locationID.startsWith(location.locationID));
 });
@@ -49,7 +49,7 @@ const getParentLocation = (module.exports.getParentLocation = function(location,
   const parts = location.locationID.split('#');
   parts.pop(); // Remove the last element
   const parentLocID = parts.join('#');
-  return locations.find(loc => loc.locationID === parentLocID);
+  return Object.values(locations).find(loc => loc.locationID === parentLocID);
 });
 
 module.exports.getSiblingLocations = function(location, locations) {

--- a/src/views/lib/geography.js
+++ b/src/views/lib/geography.js
@@ -1,13 +1,4 @@
-const levelOrder = (module.exports.levels = ['city', 'county', 'state', 'country']);
-
-const getSlug = (module.exports.getSlug = function(location) {
-  return levelOrder
-    .map(level => location[level])
-    .filter(Boolean)
-    .join(' ')
-    .replace(/(\s|,)+/g, '-')
-    .toLowerCase();
-});
+module.exports.levels = ['city', 'county', 'state', 'country'];
 
 /** Get the full name of a location
  * @param {{ city: string?; county: string?; state: string?; country: string?; }} location
@@ -47,63 +38,29 @@ module.exports.getLocationGranularityName = function(location) {
   return 'none';
 };
 
-module.exports.getChildLocations = function(location, locations) {
+const getChildLocations = (module.exports.getChildLocations = function(location, locations) {
   // Find all its children
   return locations
     .filter(loc => loc.locationID !== location.locationID)
     .filter(loc => loc.locationID.startsWith(location.locationID));
-};
-
-const parentLevelOrder = levelOrder.concat(['world']);
-const getParentLevel = (module.exports.getParentLevel = function(level) {
-  return parentLevelOrder[Math.min(parentLevelOrder.indexOf(level) + 1, parentLevelOrder.length - 1)];
 });
 
-module.exports.getParentLocation = function(location, locations) {
-  const parentLevel = getParentLevel(location.level);
-  const index = parentLevelOrder.indexOf(parentLevel);
-  const mustMatch = parentLevelOrder.slice(index, -1);
-
-  const parentLocation = Object.values(locations).find(otherLocation => {
-    if (otherLocation.level !== parentLevel) {
-      return false;
-    }
-
-    let matches = true;
-    for (const field of mustMatch) {
-      if (otherLocation[field] !== location[field]) {
-        matches = false;
-        break;
-      }
-    }
-    return matches;
-  });
-
-  // Ensure slug is present
-  if (parentLocation) {
-    parentLocation.slug = getSlug(parentLocation);
-  }
-
-  return parentLocation;
-};
+const getParentLocation = (module.exports.getParentLocation = function(location, locations) {
+  const parts = location.locationID.split('#');
+  parts.pop(); // Remove the last element
+  const parentLocID = parts.join('#');
+  return locations.find(loc => loc.locationID === parentLocID);
+});
 
 module.exports.getSiblingLocations = function(location, locations) {
-  const { level } = location;
-  const parentLevel = getParentLevel(level);
-
-  if (parentLevel === 'world') {
+  const parentLoc = getParentLocation(location, locations);
+  if (!parentLoc) {
     console.log('Will not look for siblings of %s', location.name);
     // Ideally, we find adjacent countries
     // Since this is not yet handled, just return the location
     return [location];
   }
 
-  return Object.values(locations)
-    .filter(otherLocation => {
-      return otherLocation.level === level && otherLocation[parentLevel] === location[parentLevel];
-    })
-    .map(matchingLocation => {
-      matchingLocation.slug = getSlug(matchingLocation);
-      return matchingLocation;
-    });
+  const childLocs = getChildLocations(parentLoc, locations);
+  return childLocs.filter(loc => loc.locationID !== location.locationID);
 };

--- a/src/views/lib/geography.js
+++ b/src/views/lib/geography.js
@@ -47,37 +47,11 @@ module.exports.getLocationGranularityName = function(location) {
   return 'none';
 };
 
-const childLevelOrder = levelOrder.slice().reverse();
-module.exports.getChildLocations = function(location, locations, matchLevel) {
-  const subLocations = [];
-
+module.exports.getChildLocations = function(location, locations) {
   // Find all its children
-  const locationLevel = location.level;
-  const index = childLevelOrder.indexOf(locationLevel);
-
-  const mustMatch = childLevelOrder.slice(0, index + 1);
-
-  for (const otherLocation of Object.values(locations)) {
-    let matches = true;
-    if (matchLevel) {
-      if (otherLocation.level !== matchLevel) {
-        continue;
-      }
-    }
-    for (const field of mustMatch) {
-      if (otherLocation[field] !== location[field]) {
-        matches = false;
-        break;
-      }
-    }
-    if (matches) {
-      // Ensure slug is present
-      otherLocation.slug = getSlug(otherLocation);
-      subLocations.push(otherLocation);
-    }
-  }
-
-  return subLocations;
+  return locations
+    .filter(loc => loc.locationID !== location.locationID)
+    .filter(loc => loc.locationID.startsWith(location.locationID));
 };
 
 const parentLevelOrder = levelOrder.concat(['world']);

--- a/src/views/lib/timeseries.js
+++ b/src/views/lib/timeseries.js
@@ -4,11 +4,10 @@ module.exports.filterTimeseriesByLocations = function(timeseries, locations) {
   }
 
   const subTimeseries = {};
-
   for (const date in timeseries) {
     const dateEntry = {};
     for (const location of locations) {
-      dateEntry[location.id] = timeseries[date][location.id];
+      dateEntry[location.id] = timeseries[date][`${location.id}`];
     }
     subTimeseries[date] = dateEntry;
   }


### PR DESCRIPTION
# Summary

Use Li reports from S3 instead of CDS data.

I was able to test the covidatlas.com changes locally (with yarn devcovidatlas), but couldn't check CDS as I don't know how to build/deploy the front end locally.

## Changes

### Build changes
* `yarn start` is disabled; `yarn timeseries` pulls down Li reports from s3 to dist
* `yarn start-old` and `yarn timeseries-old` run the old scripts in case you're feeling nostalgic
* `src/macros/build.js` changed to create data using new Li data structures
* dummy reports created for ratings.json and report.json

### covidatlas lambda changes
* covidatlas pages fixed (or sections disabled to expedite launch) -- see `//TODO` comments in code
* changed covidatlas.com/data links to pull from s3

### coronadatascraper.com changes
* changed links on coronadatascraper.com